### PR TITLE
Update README.md with a clarification.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The planned playable ones are GDI, Nod, Cabal, Forgotten, Scrin and Seraphs - wh
 
 ## Installation of required OpenRA build:
 
-1. Download required OpenRA version from https://github.com/DoGyAUT/OpenRA
+1. Download required OpenRA version from https://github.com/DoGyAUT/OpenRA. Make sure you have cloned the cd branch. __Using OpenRA/OpenRA's bleed branch will not work for this mod.__
 2. A precompiled build is available via our Discord group for Windows for faster access (it has also the LAA flag for more RAM usage enabled)
 3. If you don't use the precompiled build, run `make` (Linux and OSX) or start `make.cmd` in your OpenRA folder (Windows), type in "dependencies" and let it finish. After that start `make.cmd` again and type in "all" (Windows only).
 4. Start OpenRA Tiberian Sun to download Tiberian Sun content, this has to be done only once - `OpenRA.Game.exe Game.Mod=ts`


### PR DESCRIPTION
The install instructions didn't explicitly referred DoGyAuT/OpenRA's cd branch.

Fixes #75.