### PR TITLE
Gameplay changes

### DIFF
--- a/rules/cabal-infantry.yaml
+++ b/rules/cabal-infantry.yaml
@@ -21,7 +21,7 @@ HUSK:
     Mobile:
         Speed: 40
     RevealsShroud:
-        Range: 7c0
+        Range: 6c0
     Armament@PRIMARY:
         Weapon: HuskGun
         LocalOffset: 300,0,600
@@ -83,11 +83,11 @@ HHUSK:
 CYBSPY:
     Inherits@1: ^Cyborg
     Inherits@2: ^HuskUpgrades
-#    Buildable:
-#        Queue: Infantry.Cabal
-#        BuildPaletteOrder: 306
-#        Prerequisites: ~cybbar, karadr
-#        Description: Role : Scout\nHP: 200\nArmor: Medium\nSpeed: 60\nViewrange: 12\nUseless vs: Anything\n\nUpgrades: Reinforced Chassis, Alloyed Chassis, Nanomachines\nSpecial:\n - Invisibility
+    Buildable:
+        Queue: Infantry.Cabal
+        BuildPaletteOrder: 306
+        Prerequisites: ~cybbar, karadr
+        Description: Stealthy scout unit.\n\nGood vs: Nothing\n\nSpecial:\n- Stealth\n- Huge vision range\n- Receives only 50% damage from fire\n- Gets stunned by EMP\n- Crush class: Medium infantry
     Valued:
         Cost: 400
     Tooltip:
@@ -100,7 +100,7 @@ CYBSPY:
         VoiceSet: Ascentor
         Volume: 4
     Health:
-        HP: 240
+        HP: 300
     Mobile:
         Speed: 40
     RevealsShroud:
@@ -111,10 +111,14 @@ CYBSPY:
     -ProducibleWithLevel:
 #    Infiltrates:
 #        Types: SpyInfiltrate
-    Cloak:
-        Condition: crate-cloak || cloakgenerator
-        CloakSound:
+    -Cloak:
+    Cloak@self:
+        InitialDelay: 90
+        CloakDelay: 90
+        CloakSound: cloak5.aud
         UncloakSound: cloak5.aud
+        IsPlayerPalette: true
+        UncloakOn: Attack, Unload, Infiltrate, Demolish, Damage
     AnnounceOnSeen:
         PingRadar: True
         Notification: StealthUnitDetected
@@ -267,7 +271,7 @@ OVERSEER:
     Mobile:
         Speed: 40
     RevealsShroud:
-        Range: 7c0
+        Range: 6c0
     Armament@PRIMARY:
         Weapon: OverseerGun
         LocalOffset: 300,0,525

--- a/rules/cabal-structures.yaml
+++ b/rules/cabal-structures.yaml
@@ -281,7 +281,7 @@ KARADR:
         Queue: Building.Cabal
         BuildPaletteOrder: 306
         Prerequisites: anypower, kproc, ~structures.cabal
-        Description: Provides an overview of the battlefield.\n\nSpecial:\n- Provides minimap\n- Allows improving powerplants
+        Description: Provides an overview of the battlefield.\n\nSpecial:\n- Provides minimap\n- Allows improving powerplants\n- Detects underground units
     Valued:
         Cost: 1500
     Tooltip:
@@ -320,7 +320,7 @@ KARADR:
     ProvidesPrerequisite@buildingname:
     RenderDetectionCircle:
     DetectCloaked:
-        Range: 20c0
+        Range: 15c0
         CloakTypes: Underground        
     GrantExternalConditionPower@powerboost:
         OrderName: GrantPowerBoostPowerInfoOrder

--- a/rules/cabal-support.yaml
+++ b/rules/cabal-support.yaml
@@ -106,7 +106,7 @@ KABLASR:
     Health:
         HP: 1200
     RevealsShroud:
-        Range: 11c0
+        Range: 9c0
     Turreted:
         TurnSpeed: 5
         InitialFacing: 222
@@ -151,7 +151,7 @@ KABCAN:
     Health:
         HP: 1440
     RevealsShroud:
-        Range: 11c0
+        Range: 10c0
     Turreted:
         TurnSpeed: 5
         InitialFacing: 0
@@ -196,7 +196,7 @@ KDARK:
     Health:
         HP: 2400
     RevealsShroud:
-        Range: 16c0
+        Range: 13c0
     Armament:
         Weapon: CabalObeliskLaserAA
         LocalOffset: 1600,0,2000
@@ -246,7 +246,7 @@ KOBEL:
     Health:
         HP: 3750
     RevealsShroud:
-        Range: 13c0
+        Range: 10c0
     Armament:
         Weapon: CabalObeliskLaser
         LocalOffset: 1600,0,800

--- a/rules/defaults.yaml
+++ b/rules/defaults.yaml
@@ -2034,8 +2034,8 @@
     WithSpriteBody:
     GrantPeriodicCondition@kill:
         Condition: killfire
-        CooldownDuration: 500
-        ActiveDuration: 200
+        CooldownDuration: 100
+        ActiveDuration: 50
     Explodes:
         Weapon: NapalmShrapnelSmudge
         EmptyWeapon: NapalmShrapnelSmudge

--- a/rules/fauna.yaml
+++ b/rules/fauna.yaml
@@ -21,9 +21,9 @@ DOGGIE:
         Weapon: FiendShardGreen
     AttackFrontal:
     AttackWander:
-        WanderMoveRadius: 4
-        MinMoveDelayInDelay: 100
-        MaxMoveDelayInDelay: 180
+        WanderMoveRadius: 6
+        MinMoveDelay: 50
+        MaxMoveDelay: 300
 
 JFISH:
     Inherits: ^Visceroid

--- a/rules/forgotten-structures.yaml
+++ b/rules/forgotten-structures.yaml
@@ -300,7 +300,7 @@ FARADR:
         Queue: Building.Forg
         BuildPaletteOrder: 406
         Prerequisites: anypower, fproc, ~structures.forgotten
-        Description: Provides an overview of the battlefield.\nCan detect cloaked units.\nRequires power to operate.
+        Description: Provides an overview of the battlefield.\nCan detect cloaked units.\nRequires power to operate.\n- Detects underground units
     Valued:
         Cost: 1500
     Tooltip:
@@ -345,7 +345,7 @@ FARADR:
     ProvidesPrerequisite@buildingname:
     RenderDetectionCircle:
     DetectCloaked:
-        Range: 20c0
+        Range: 15c0
         CloakTypes: Underground
     
 FHOVEL:

--- a/rules/gdi-aircraft.yaml
+++ b/rules/gdi-aircraft.yaml
@@ -654,6 +654,9 @@ FHAWK:
 #        SelfReloads: True
 #        SelfReloadDelay: 5
     AutoTarget:
+		TargetWhenIdle: false
+		TargetWhenDamaged: false
+		EnableStances: false    
     RenderSprites:
     RenderVoxels:
     WithVoxelBody:
@@ -749,6 +752,9 @@ HORNET:
 #        SelfReloads: True
 #        SelfReloadDelay: 5
     AutoTarget:
+		TargetWhenIdle: false
+		TargetWhenDamaged: false
+		EnableStances: false    
     RenderSprites:
     RenderVoxels:
     WithVoxelBody:
@@ -835,6 +841,9 @@ CONDOR:
         PipType: Ammo
         PipTypeEmpty: AmmoEmpty
     AutoTarget:
+		TargetWhenIdle: false
+		TargetWhenDamaged: false
+		EnableStances: false    
     RenderSprites:
     RenderVoxels:
     WithVoxelBody:

--- a/rules/gdi-infantry.yaml
+++ b/rules/gdi-infantry.yaml
@@ -156,10 +156,14 @@ SCOUT:
     AttackFrontal:
 #    Infiltrates:
 #        Types: SpyInfiltrate
-    Cloak:
-        RequiresCondition: upgrade.stealth || crate-cloak || cloakgenerator
+    -Cloak:
+    Cloak@self:
+        InitialDelay: 90
+        CloakDelay: 90
         CloakSound: cloak5.aud
         UncloakSound: cloak5.aud
+        IsPlayerPalette: true
+        UncloakOn: Attack, Unload, Infiltrate, Demolish, Damage
     AnnounceOnSeen:
         PingRadar: True
         Notification: StealthUnitDetected
@@ -304,7 +308,7 @@ ZMARINE:
         Prerequisites: ~gapile, ~!t1, ~upgrade.zc
         Description: ZOCOM's variant of the Marine.\n\nGood vs: Infantry\n\nSpecial:\n- Immune to Tiberium radiation\n- Crush class: Light Infantry
     Valued:
-        Cost: 350
+        Cost: 200
     Tooltip:
         Name: Zone Marine
     Selectable:
@@ -326,7 +330,7 @@ ZMARINE:
             PurpleTiberium: 70
                 PathingCost: 0
     RevealsShroud:
-        Range: 7c0
+        Range: 6c0
     Armament@PRIMARY:
         Weapon: ZoneMarineGun
         LocalOffset: 300,0,480

--- a/rules/gdi-structures.yaml
+++ b/rules/gdi-structures.yaml
@@ -295,7 +295,7 @@ GARADR:
         Queue: Building.GDI
         BuildPaletteOrder: 106
         Prerequisites: anypower, gproc, ~structures.gdi
-        Description: Provides an overview of the battlefield.\n\nSpecial:\n- Provides minimap\n- Can call scout run if powered
+        Description: Provides an overview of the battlefield.\n\nSpecial:\n- Provides minimap\n- Detects underground units
     Valued:
         Cost: 1500
     Tooltip:
@@ -329,30 +329,8 @@ GARADR:
     ProvidesPrerequisite@buildingname:
     RenderDetectionCircle:
     DetectCloaked:
-        Range: 20c0
+        Range: 15c0
         CloakTypes: Underground
-    AirstrikePower@orcascout:
-        OrderName: OrcaScoutRun
-        Prerequisites: garadr
-        Icon: orcascout
-        ChargeTime: 180
-        Description: Orca Scout Run
-        LongDesc: Reveals an area of the map and cloaked enemy units.
-        SelectTargetSound: orca_m12.aud
-        EndChargeSound: orca_s10.aud
-        LaunchSound: orca_a10.aud
-        CameraActor: camera.orcascout
-        CameraRemoveDelay: 300
-        UnitType: orca_g
-        SquadSize: 3
-        SquadOffset: -3072,3072,0
-        QuantizedFacings: 8
-        DisplayBeacon: true
-        DisplayRadarPing: True
-        BeaconPoster: orcascout
-        ArrowSequence: arrow
-        CircleSequence: circles
-        ClockSequence: clock
     
 GAARMORY:
     Inherits: ^Building
@@ -493,7 +471,7 @@ GAHPAD:
         BuildPaletteOrder: 108
         Queue: Building.GDI
         Prerequisites: anypower, garadr, ~structures.gdi
-        Description: Produces, rearms and repairs aircrafts.
+        Description: Produces, rearms and repairs aircrafts.\n\nSpecial:\n- Can call scout run
     Building:
         Footprint: xx xx
         Dimensions: 2,2
@@ -539,7 +517,28 @@ GAHPAD:
     ProvidesPrerequisite@buildingname:
     ProvidesAIPrerequisite@OrcatransAI:
         Prerequisite: OrcatransAI
-
+    AirstrikePower@orcascout:
+        OrderName: OrcaScoutRun
+        Prerequisites: gahpad
+        Icon: orcascout
+        ChargeTime: 180
+        Description: Orca Scout Run
+        LongDesc: Reveals an area of the map and cloaked enemy units.
+        SelectTargetSound: orca_m12.aud
+        EndChargeSound: orca_s10.aud
+        LaunchSound: orca_a10.aud
+        CameraActor: camera.orcascout
+        CameraRemoveDelay: 300
+        UnitType: orca_g
+        SquadSize: 3
+        SquadOffset: -3072,3072,0
+        QuantizedFacings: 8
+        DisplayBeacon: true
+        DisplayRadarPing: True
+        BeaconPoster: orcascout
+        ArrowSequence: arrow
+        CircleSequence: circles
+        ClockSequence: clock
 GADEPT:
     Inherits: ^Building
     Valued:

--- a/rules/gdi-support.yaml
+++ b/rules/gdi-support.yaml
@@ -105,7 +105,7 @@ GAMG:
     Health:
         HP: 1400
     RevealsShroud:
-        Range: 10c0
+        Range: 8c0
     BodyOrientation:
         QuantizedFacings: 32
     AutoTarget:
@@ -261,7 +261,7 @@ GASENTUR:
     Health:
         HP: 1400
     RevealsShroud:
-        Range: 10c0
+        Range: 11c0
     BodyOrientation:
         QuantizedFacings: 32
     RenderDetectionCircle:
@@ -319,7 +319,7 @@ GAMIS:
     Health:
         HP: 1400
     RevealsShroud:
-        Range: 11c0
+        Range: 9c0
     BodyOrientation:
         QuantizedFacings: 32
     AutoTarget:
@@ -377,7 +377,7 @@ GACAN:
     Health:
         HP: 1400
     RevealsShroud:
-        Range: 11c0
+        Range: 8c0
     BodyOrientation:
         QuantizedFacings: 32
     AutoTarget:
@@ -426,7 +426,7 @@ GAMORTAR:
 #    WithWallSpriteBody:
 #        Type: wall
     Valued:
-        Cost: 2000
+        Cost: 1500
     Tooltip:
         Name: Howitzer Tower
     Buildable:
@@ -561,7 +561,7 @@ GAFORT:
     Inherits: ^Defense
     WithSpriteBody:
     Valued:
-        Cost: 1000
+        Cost: 800
     Tooltip:
         Name: Fortress Garrison Bunker
     Buildable:
@@ -577,12 +577,12 @@ GAFORT:
         Class: gafort
     DisabledOverlay:
     Health:
-        HP: 2600
+        HP: 3000
     RevealsShroud:
-        Range: 16c0
-    RenderDetectionCircle:
-    DetectCloaked:
-        Range: 6c0
+        Range: 10c0
+#    RenderDetectionCircle:
+#    DetectCloaked:
+#        Range: 6c0
     Turreted:
         TurnSpeed: 255
     -QuantizeFacingsFromSequence:

--- a/rules/gdi-vehicles.yaml
+++ b/rules/gdi-vehicles.yaml
@@ -229,7 +229,7 @@ VULTURE:
     Health:
         HP: 950
     RevealsShroud:
-        Range: 9c0
+        Range: 10c0
     BodyOrientation:
         QuantizedFacings: 32
     Turreted:

--- a/rules/nod-aircraft.yaml
+++ b/rules/nod-aircraft.yaml
@@ -492,6 +492,9 @@ RAVEN:
     AttackPlane:
         FacingTolerance: 45
     AutoTarget:
+		TargetWhenIdle: false
+		TargetWhenDamaged: false
+		EnableStances: false    
 
 SCRINB:
     Inherits: ^AttackAdvancedPlane
@@ -588,7 +591,7 @@ VERTIGO:
         RenderSelectionBars: False
     Aircraft:
         TurnSpeed: 4
-        Speed: 180
+        Speed: 220
     Health:
         HP: 1200
     RevealsShroud:

--- a/rules/nod-infantry.yaml
+++ b/rules/nod-infantry.yaml
@@ -107,7 +107,7 @@ CHAMSPY:
         Prerequisites: ~nahand, napyra, ~technology
         Description: Technology Nod´s unarmed and invisible agent.\n\nGood vs: Nothing\n\nSpecial:\n- Stealth\n- Can steal money out of refineries and silos\n- Can sabotage power\n- Huge vision range\n- Crush class: Light Infantry
     Valued:
-        Cost: 1000
+        Cost: 800
     Tooltip:
         Name: Chameleon Spy
     Selectable:
@@ -264,6 +264,7 @@ FANATIC:
     WithInfantryBody:
         IdleSequences: idle1,idle2
     Explodes:
+        EmptyWeapon: FanticBoomExplosion
         Weapon: FanticBoomExplosion
     AutoTarget:
         ScanRadius: 5

--- a/rules/nod-structures.yaml
+++ b/rules/nod-structures.yaml
@@ -386,7 +386,7 @@ NARADR:
         Queue: Building.Nod
         BuildPaletteOrder: 206
         Prerequisites: anypower, nproc, ~structures.nod, ~ideology
-        Description: Provides an overview of the battlefield.\n\nSpecial:\n- Provides minimap\n- Provides special infantry taskforce drop (Technology)\n- Provides a special buff ability to increase attack and movement speed of infantry (Propaganda)
+        Description: Provides an overview of the battlefield.\n\nSpecial:\n- Provides minimap\n- Provides special infantry taskforce drop (Technology)\n- Provides a special buff ability to increase attack and movement speed of infantry (Propaganda)\n- Detects underground units
     Valued:
         Cost: 1500
     Tooltip:
@@ -422,7 +422,7 @@ NARADR:
     ProvidesPrerequisite@buildingname:
     RenderDetectionCircle:
     DetectCloaked:
-        Range: 20c0
+        Range: 15c0
         CloakTypes: Underground
     ParatroopersPower@techcarry:
         UnitType: valkyrie.support

--- a/rules/nod-support.yaml
+++ b/rules/nod-support.yaml
@@ -105,7 +105,7 @@ NAFLAMER:
     Health:
         HP: 1200
     RevealsShroud:
-        Range: 9c0
+        Range: 6c0
     BodyOrientation:
         QuantizedFacings: 32
     RenderRangeCircle:
@@ -221,7 +221,7 @@ NALASR:
     Health:
         HP: 1800
     RevealsShroud:
-        Range: 11c0
+        Range: 9c0
     BodyOrientation:
         QuantizedFacings: 32
     RenderRangeCircle:
@@ -283,7 +283,7 @@ NASAM:
     Health:
         HP: 1200
     RevealsShroud:
-        Range: 11c0
+        Range: 9c0
     BodyOrientation:
         QuantizedFacings: 32
     RenderRangeCircle:
@@ -373,7 +373,7 @@ NAOBEL:
     Health:
         HP: 3000
     RevealsShroud:
-        Range: 15c0
+        Range: 10c0
     Armament@normalA:
         Weapon: ObeliskLaser
         LocalOffset: 3150,-450,800
@@ -446,7 +446,7 @@ NAPULS:
     Health:
         HP: 2600
     RevealsShroud:
-        Range: 8c0
+        Range: 4c0
     Turreted:
         TurnSpeed: 10
         InitialFacing: 300
@@ -561,7 +561,7 @@ NASTLH:
     Health:
         HP: 1200
     RevealsShroud:
-        Range: 6c0
+        Range: 4c0
     WithIdleOverlay@pulse:
         Sequence: pulse
         PauseOnLowPower: True

--- a/rules/nod-tech.yaml
+++ b/rules/nod-tech.yaml
@@ -188,7 +188,7 @@ upgrade.propaganda.bluehell:
         Prerequisites: ~propaganda, napyra, ~!upgrade.bluehell
         Queue: Tech.Nod
         BuildLimit: 1
-        Description: Improves the damage the following units and buildings:\n- Black Hand Flamer\n- Pyradon Tank\n- Specter Artillery\n- Flame Turret
+        Description: Improves the damage the following units and buildings:\n- Raven\n- Black Hand Flamer\n- Pyradon Tank\n- Specter Artillery\n- Flame Turret
     Valued:
         Cost: 1500
     RenderSprites:

--- a/rules/nod-vehicles.yaml
+++ b/rules/nod-vehicles.yaml
@@ -1061,40 +1061,40 @@ STNK:
         MuzzleSequence: muzzle
         MuzzlePalette: apolra50alpha
         RequiresCondition: !upgrade.emp
-    Armament@2:
-        Weapon: StealthTankMissile
-        LocalOffset: 128,164,600, 128,-164,600
-        MuzzleSequence: muzzle
-        MuzzlePalette: apolra50alpha
-        FireDelay: 10
-        RequiresCondition: !upgrade.emp
-    Armament@3:
-        Weapon: StealthTankMissile
-        LocalOffset: 128,164,600, 0,-164,600
-        MuzzleSequence: muzzle
-        MuzzlePalette: apolra50alpha
-        FireDelay: 20
-        RequiresCondition: !upgrade.emp
+#    Armament@2:
+#        Weapon: StealthTankMissile
+#        LocalOffset: 128,164,600, 128,-164,600
+#        MuzzleSequence: muzzle
+#        MuzzlePalette: apolra50alpha
+#        FireDelay: 10
+#        RequiresCondition: !upgrade.emp
+#    Armament@3:
+#        Weapon: StealthTankMissile
+#        LocalOffset: 128,164,600, 0,-164,600
+#        MuzzleSequence: muzzle
+#        MuzzlePalette: apolra50alpha
+#        FireDelay: 20
+#        RequiresCondition: !upgrade.emp
     Armament@1upgrade:
         Weapon: StealthTankMissileEMP
         LocalOffset: 128,164,600, 128,-164,600
         MuzzleSequence: muzzle
         MuzzlePalette: apolra50alpha
         RequiresCondition: upgrade.emp
-    Armament@2upgrade:
-        Weapon: StealthTankMissileEMP
-        LocalOffset: 128,164,600, 128,-164,600
-        MuzzleSequence: muzzle
-        MuzzlePalette: apolra50alpha
-        FireDelay: 10
-        RequiresCondition: upgrade.emp
-    Armament@3upgrade:
-        Weapon: StealthTankMissileEMP
-        LocalOffset: 128,164,600, 0,-164,600
-        MuzzleSequence: muzzle
-        MuzzlePalette: apolra50alpha
-        FireDelay: 20
-        RequiresCondition: upgrade.emp
+#    Armament@2upgrade:
+#        Weapon: StealthTankMissileEMP
+#        LocalOffset: 128,164,600, 128,-164,600
+#        MuzzleSequence: muzzle
+#        MuzzlePalette: apolra50alpha
+#        FireDelay: 10
+#        RequiresCondition: upgrade.emp
+#    Armament@3upgrade:
+#        Weapon: StealthTankMissileEMP
+#        LocalOffset: 128,164,600, 0,-164,600
+#        MuzzleSequence: muzzle
+#        MuzzlePalette: apolra50alpha
+#        FireDelay: 20
+#        RequiresCondition: upgrade.emp
     Armament@antiair:
         Weapon: StealthTankMissileAA
         LocalOffset: 128,164,600, 128,-164,600

--- a/rules/shared-structures.yaml
+++ b/rules/shared-structures.yaml
@@ -72,6 +72,7 @@ CAHOSP:
         HP: 2400
     -MustBeDestroyed:
     -Sellable:
+    -GivesBuildableArea:
     RevealsShroud:
         Range: 6c0
     ActorLostNotification:
@@ -79,7 +80,7 @@ CAHOSP:
     AutoTargetIgnore:
     Capturable:
     ExternalCapturable:
-        CaptureCompleteTime: 9
+        CaptureCompleteTime: 7
     ProximityExternalCondition:
         Condition: medic_heal
         Range: 500c0
@@ -95,6 +96,7 @@ CAARMR:
         HP: 2400
     -MustBeDestroyed:
     -Sellable:
+    -GivesBuildableArea:    
     RevealsShroud:
         Range: 3c0
     ActorLostNotification:
@@ -104,7 +106,7 @@ CAARMR:
         Sequence: idle-flag
     Capturable:
     ExternalCapturable:
-        CaptureCompleteTime: 9
+        CaptureCompleteTime: 7
     ProvidesPrerequisite:
         Prerequisite: armory.upgraded
 
@@ -119,6 +121,7 @@ CAARAY:
         HP: 2400
     -MustBeDestroyed:
     -Sellable:
+    -GivesBuildableArea:    
     RevealsShroud:
         Range: 15c0
     ActorLostNotification:
@@ -133,4 +136,4 @@ CAARAY:
         Sequence: idle-light
     Capturable:
     ExternalCapturable:
-        CaptureCompleteTime: 9
+        CaptureCompleteTime: 7

--- a/weapons/cabal-weapons.yaml
+++ b/weapons/cabal-weapons.yaml
@@ -2,7 +2,7 @@ HuskGun:
     Inherits: ^Bullet
     Inherits@wh: ^BulletWH
     ReloadDelay: 45
-    Range: 6c0
+    Range: 5c0
     Burst: 4
     BurstDelay: 2
     Report: rifle_c1.aud, rifle_c2.aud, rifle_c3.aud
@@ -11,7 +11,7 @@ HuskGun:
         Palette: effect
         Inaccuracy: 0c128
     Warhead@1Dam: SpreadDamage
-        Spread: 0c128
+        Spread: 128
         Damage: 25
         
 OverseerGun:
@@ -20,7 +20,7 @@ OverseerGun:
     ReloadDelay: 65
     Burst: 5
     BurstDelay: 2
-    Range: 6c0
+    Range: 5c0
     Report: fg42_01.aud, fg42_02.aud, fg42_03.aud
     Projectile: BulletAS
         Inaccuracy: 0c128
@@ -598,7 +598,7 @@ CabalObeliskLaserAA:
     Inherits: ^BasicLaser
     Inherits@wh: ^LaserWH
     ReloadDelay: 120
-    Range: 13c0
+    Range: 12c0
     Report: cablaser01.aud
     ValidTargets: Air, MidAir, HighAir
     Projectile: LaserZap

--- a/weapons/gdi-weapons.yaml
+++ b/weapons/gdi-weapons.yaml
@@ -411,14 +411,14 @@ ZoneMarineGun:
     Inherits: ^Bullet
     Inherits@wh: ^BulletWH
     ReloadDelay: 60
-    Range: 6c0
+    Range: 5c0
     Burst: 3
     BurstDelay: 4
     Report: carbine_g1.aud, carbine_g2.aud
     Projectile: BulletAS
-        bullet
         Inaccuracy: 0c128
     Warhead@1Dam: SpreadDamage
+        Spread: 128
         Damage: 50
 
 ZoneMarineGunGarrison:
@@ -961,7 +961,7 @@ HowitzerTurretGun:
     MinRange: 4c0
     Warhead@1Dam: SpreadDamage
         Spread: 768
-        Damage: 500
+        Damage: 300
     Warhead@2Eff: CreateEffect
         Explosions: fireexpl
         ExplosionPalette: effect
@@ -1063,7 +1063,7 @@ VultureMissile:
 	Inherits@wh: ^HEWH
     ReloadDelay: 80
     Burst: 2
-    Range: 8c0
+    Range: 9c0
     Report: launcher01.aud, launcher02.aud, launcher03.aud, launcher04.aud
     ValidTargets: Air, MidAir, HighAir
     Projectile: Missile

--- a/weapons/nod-weapons.yaml
+++ b/weapons/nod-weapons.yaml
@@ -493,14 +493,14 @@ RaiderGunAttack:
         Spread: 0c64
         Damage: 15
         Versus:
-            Air: 50
+            Air: 25
         
 RaiderGunLaser:
     Inherits: ^BasicLaser
     Inherits@wh: ^LaserWH
-    ReloadDelay: 40
-    Burst: 3
-    BurstDelay: 3
+    ReloadDelay: 20
+#    Burst: 3
+#    BurstDelay: 3
     Range: 6c0
     Report: lasergun01.aud, lasergun02.aud, lasergun03.aud, lasergun04.aud, lasergun05.aud, lasergun06.aud, lasergun07.aud, lasergun08.aud
     ValidTargets: Ground, Air, MidAir, HighAir   
@@ -515,10 +515,10 @@ RaiderGunLaser:
         SecondaryBeamColor: FFFFFF
     Warhead@1Dam: SpreadDamage
         Spread: 42
-        Damage: 26
+        Damage: 30
         Versus:
             Air: 50
-            Infantry: 350
+            Infantry: 100
         ValidTargets: Ground, Air, MidAir, HighAir   
     Warhead@2Eff: CreateEffect
         Explosions: plasmaexpl2
@@ -855,7 +855,7 @@ VertigoBombGas:
         ContrailColor: 00FF64
     Warhead@1Dam: SpreadDamage
         Spread: 1c512
-        Damage: 3000
+        Damage: 2000
     Warhead@2Eff: CreateEffect
         Explosions: tiberiumbomb
         ExplosionPalette: tiberiumbomb50
@@ -894,7 +894,7 @@ VertigoBombNapalm:
         ContrailWidth: 15
     Warhead@1Dam: SpreadDamage
         Spread: 1c512
-        Damage: 1500
+        Damage: 1000
     Warhead@2Eff: CreateEffect
         Explosions: napalmnuke
         ExplosionPalette: napalmnuke50
@@ -1603,6 +1603,8 @@ HavocLaserFire:
 FlamerTurretBlueFireballLauncher:
     Inherits@wh: ^FireWH
     ReloadDelay: 50
+    Burst: 2
+    BurstDelay: 20    
     Range: 5c256
     Report: firstrm1.aud
     Projectile: BulletAS
@@ -1615,7 +1617,7 @@ FlamerTurretBlueFireballLauncher:
     InvalidTargets: Flameproof
     Warhead@1Dam: SpreadDamage
         Spread: 1c0
-        Damage: 100
+        Damage: 50
         Falloff: 100, 90, 80
     Warhead@2Eff: CreateEffect
         Explosions: fire01a, fire02a, fire03a
@@ -1631,6 +1633,8 @@ FlamerTurretBlueFireballLauncher:
 FlamerTurretFireballLauncher:
     Inherits@wh: ^FireWH
     ReloadDelay: 100
+    Burst: 2
+    BurstDelay: 20    
     Range: 5c256
     Report: flamtnk1.aud
     Projectile: BulletAS
@@ -1643,7 +1647,7 @@ FlamerTurretFireballLauncher:
     InvalidTargets: Flameproof
     Warhead@1Dam: SpreadDamage
         Spread: 1c0
-        Damage: 75
+        Damage: 40
         Falloff: 100, 80
     Warhead@2Eff: CreateEffect
         Explosions: fire01a, fire02a, fire03a
@@ -1680,7 +1684,7 @@ FanticBoomExplosion:
     Inherits@wh: ^HEAPWH
     Warhead@1Dam: SpreadDamage
         Spread: 0c512
-        Damage: 0
+        Damage: 500
         Falloff: 100, 75, 50, 25, 0
         AffectsParent: True
     Warhead@2Eff: CreateEffect
@@ -1752,8 +1756,8 @@ StealthTankMissile:
 	Inherits@wh: ^APWH
     ReloadDelay: 175
     Range: 9c0
-    Burst: 2
-    BurstDelay: 0
+    Burst: 6
+    BurstDelay: 10
     Report: rocket01.aud, rocket02.aud, rocket03.aud, rocket04.aud, rocket05.aud, rocket06.aud
     ValidTargets: Ground
     Projectile: Missile
@@ -1763,7 +1767,7 @@ StealthTankMissile:
         Inaccuracy: 0c512
     Warhead@1Dam: SpreadDamage
         Spread: 128
-        Damage: 110
+        Damage: 120
         ValidTargets: Ground
 
 StealthTankMissileEMP:
@@ -1771,8 +1775,8 @@ StealthTankMissileEMP:
 	Inherits@wh: ^APWH
     ReloadDelay: 175
     Range: 9c0
-    Burst: 2
-    BurstDelay: 0
+    Burst: 6
+    BurstDelay: 10
     Report: rocket01.aud, rocket02.aud, rocket03.aud, rocket04.aud, rocket05.aud, rocket06.aud
     ValidTargets: Ground
     Projectile: Missile
@@ -1804,7 +1808,7 @@ StealthTankMissileAA:
     ReloadDelay: 100
     Range: 10c0
     Burst: 6
-    BurstDelay: 5
+    BurstDelay: 10
     Report: rocket01.aud, rocket02.aud, rocket03.aud, rocket04.aud, rocket05.aud, rocket06.aud
     ValidTargets: Air, MidAir
     Projectile: Missile
@@ -1815,7 +1819,7 @@ StealthTankMissileAA:
         RangeLimit: 20c0
     Warhead@1Dam: SpreadDamage
         Spread: 128
-        Damage: 100
+        Damage: 120
         ValidTargets: Air, MidAir
         
 HailstormMissile:


### PR DESCRIPTION
Global:
Radars: detectionrange of underground vehicles from 20c0 to 15c0
Jets: Firehakw, Hornet, Condor and Raven do not automatically attack anymore (Holdfire)
Changed Critter Tibeirum Fiend movement
Hospitals, Civilian Arrays and Armorys now have the correct captured time (from 9 to 7)

GDI:
Scout is now correctly cloaked
Orca scout run from radar to helipad
Vulcan Tower: revealsshroud from 10c0 to 8c0
Sniper-Sensor Tower: revealsshroud from 10c0 to 11c0
SAM Tower: revealsshroud from 11c0 to 9c0
Guardian Tower: revealsshroud from 11c0 to 8c0
Howitzer Tower: HowitzerTurretGun damage from 500 to 300 and cost from 2000$ to 1500$
Fortress Garrison Bunker: revealsshroud from 16c0 to 10c0, HP from 2600 to 3000, cost from 1000$ to 800$, remove cloack detection
Vulture: anti air missiles needs +1c0 mor attackrange against air, revealsshroud from 9c0 to 10c0
Zone Marine: cost from 350$ to 250$, attackrange from 6c0 to 5c0, revealsshroud from 7c0 to 6c0, ZoneMarineGun something is wrong between projectile and inaccuracy, ZoneMarineGun has no damage spread: from 0 to 128

Nod:
Chameleon Spy: cost from 1000$ to 800$
Fanatics: now also do explosion damage upon death, damage from 0 to 500
Vertigo: movementspeed from 180 to 220
Tiberium strike: damage from 3000 to 2000
Vertigobombnapalm: damage from 1500 to 1000, CooldownDuration: 100, ActiveDuration: 50
Raider Buggy: RaiderGunAttack damage against air from 50% to 25%, RaiderGunLaser needs a rework, remove the burst, reloadspeed from 40 to 20, damage from 26 to 30, damage vs infantry from 350 to 100
Flame Turret: change its weapon to burst (for FlamerTurretFireballLauncher and FlamerTurretBlueFireballLauncher) with a delay of 20, FlamerTurretFireballLauncher damage from 75 to 40, FlamerTurretBlueFireballLauncher damage from 100 to 50, revealsshroud from 9c0 to 6c0
Laser Turret: revealsshroud from 11c0 to 9c0
SAM Site: revealsshroud from 11c0 to 9c0
Obelisk of Light: revealsshroud from 15c0 to 10c0
E.M. Pulse Cannon: revealsshroud from 8c0 to 4c0
Stealth Generator: revealsshroud from 6c0 to 4c0
Added to the tooltip of bluehellinferno that Ravens do benefit from this upgrade
Stealth Tank: damage from 110 to 120 against ground and air, now has a burstdelay of 10

Cabal:
Informer enabled again
Husk: HuskGun attackrange from 7c0 to 6c0, visionrange from 6c0 to 5c0, HuskGun spreaddamage from 0c128 to 128 (does that even change anything?)
Overseer: weapon attackrange from 6c0 to 5c0, visionrange from 8c0 to 7c0
Obelisk of Darkness: attackrange from 13c0 to 12c0, revealsshroud from 16c0 to 13c0
Core Obelisk: revealsshroud from 13c0 to 10c0
Plasma Blaster: revealsshroud from 11c0 to 10c0
Sabercut: revealsshroud from 11c0 to 9c0