### PR TITLE
Gameplay changes

### DIFF
--- a/rules/cabal-infantry.yaml
+++ b/rules/cabal-infantry.yaml
@@ -47,7 +47,7 @@ HHUSK:
         Queue: Infantry.Cabal
         BuildPaletteOrder: 301
         Prerequisites: ~cybbar
-        Description: Cabals standard infantry production type.\n\nGood vs: Vehicles\n\nSpecial:\n- Receives only 50% damage from fire\n- Gets stunned by EMP\n- Crush class: Medium infantry
+        Description: Cabals standard infantry production type.\n\nGood vs: Ground Targets\n\nSpecial:\n- Receives only 50% damage from fire\n- Gets stunned by EMP\n- Crush class: Medium infantry
     Valued:
         Cost: 300
     Tooltip:
@@ -104,7 +104,7 @@ CYBSPY:
     Mobile:
         Speed: 40
     RevealsShroud:
-        Range: 12c0
+        Range: 10c0
     WithInfantryBody:
         IdleSequences: idle1,idle2,idle3
     AttackFrontal:

--- a/rules/cabal-structures.yaml
+++ b/rules/cabal-structures.yaml
@@ -96,7 +96,7 @@ KPR:
     Selectable:
         Bounds: 88, 80, 2, -12
     Health:
-        HP: 1400
+        HP: 1200
     RevealsShroud:
         Range: 4c0
     WithIdleOverlay@LIGHTS:
@@ -182,7 +182,7 @@ CYBBAR:
     Selectable:
         Bounds: 116, 78, 3, -8
     Health:
-        HP: 1200
+        HP: 800
     RevealsShroud:
         Range: 5c0
     Exit@1:
@@ -416,7 +416,7 @@ KABTECH:
     RevealsShroud:
         Range: 5c0
     Power:
-        Amount: -200
+        Amount: -300
     RequiresPower:
     CanPowerDown:
         IndicatorPalette: mouse

--- a/rules/cabal-vehicles.yaml
+++ b/rules/cabal-vehicles.yaml
@@ -384,7 +384,7 @@ SILVER:
     WithVoxelBody:
     -ThrowsShrapnel@human:
     PortableChrono:
-        ChargeDelay: 10
+        ChargeDelay: 300
         KillCargo: False
         TargetCursor: move
         TargetBlockedCursor: move-blocked

--- a/rules/civilian-structures.yaml
+++ b/rules/civilian-structures.yaml
@@ -1102,7 +1102,7 @@ GALITE:
         Sequence: lighting
         Palette: alpha
     Selectable:
-        Bounds: 25, 35, 0, -12
+        Bounds: 25, 35, 0, -1
     -Cloak:
     -ExternalCondition@EXTERNALCLOAK1:
     -ExternalCondition@EXTERNALCLOAK2:

--- a/rules/defaults.yaml
+++ b/rules/defaults.yaml
@@ -389,7 +389,8 @@
         RequiresCondition: firedamage
     ExternalCondition@firedamage:
         Condition: firedamage
-
+    AutoTargetIgnore:
+        
 ^Building:
     Inherits@1: ^BasicBuilding
     Inherits@2: ^EmpDisable
@@ -1146,6 +1147,15 @@
         RequiresCondition: repair_heal
     ExternalCondition@repair_golem:
         Condition: repair_heal
+    WithDecoration@repair_golem:
+        Image: pips
+        Sequence: medic
+        Palette: pips
+        ReferencePoint: Bottom, Left
+        Offset: 0, 0
+        ZOffset: 256
+        ValidStances: Ally, Neutral
+        RequiresCondition: repair_heal
         
 ^HeavyCyborg:
     Inherits@1: ^Cyborg
@@ -1520,7 +1530,7 @@
         CrushClasses: lightvehicle
         WarnProbability: 0
     Mobile:
-        Crushes: crate, infantry, sandbags, mutant, mutantfearless
+        Crushes: crate
 
 ^MediumVehicle
     Crushable:
@@ -2137,6 +2147,7 @@
     RevealsShroud:
         Range: 6c0
     RevealOnFire:
+    -AutoTargetIgnore:
 
 ^Train:
     Inherits@1: ^EmpDisable

--- a/rules/fauna.yaml
+++ b/rules/fauna.yaml
@@ -7,7 +7,7 @@ DOGGIE:
         Radius: 213
         HP: 400
 	Valued: 
- 		Cost: 1
+ 		Cost: 300
     RevealsShroud:
         Range: 6c0
     Mobile:

--- a/rules/forgotten-structures.yaml
+++ b/rules/forgotten-structures.yaml
@@ -97,7 +97,7 @@ FAPOWR:
     Selectable:
         Bounds: 88, 80, 2, -12
     Health:
-        HP: 1000
+        HP: 1200
     RevealsShroud:
         Range: 4c0
     Power:
@@ -197,7 +197,7 @@ FABAR:
     Selectable:
         Bounds: 88, 56, 0, -8
     Health:
-        HP: 960
+        HP: 800
     RevealsShroud:
         Range: 5c0
     RallyPoint:
@@ -407,7 +407,7 @@ FAHPAD:
         Footprint: xx xx
         Dimensions: 2,2
     Health:
-        HP: 960
+        HP: 800
     RevealsShroud:
         Range: 5c0
     Exit@1:

--- a/rules/gdi-infantry.yaml
+++ b/rules/gdi-infantry.yaml
@@ -87,7 +87,7 @@ E2:
         Prerequisites: ~gapile, garadr, ~upgrade.st
         Description: Steel Talons advanced infantry.\n\nGood vs: Ground Targets\n\nSpecial:\n- Bouncing shot\n- AOE damage\n- EMP effect on veterancy rank 5\n- Crush class: Light Infantry
     Valued:
-        Cost: 300
+        Cost: 250
     Tooltip:
         Name: Disc Thrower
     Selectable:
@@ -152,7 +152,7 @@ SCOUT:
     Mobile:
         Speed: 50
     RevealsShroud:
-        Range: 12c0
+        Range: 10c0
     AttackFrontal:
 #    Infiltrates:
 #        Types: SpyInfiltrate

--- a/rules/gdi-structures.yaml
+++ b/rules/gdi-structures.yaml
@@ -197,7 +197,7 @@ GAPILE:
     Selectable:
         Bounds: 88, 56, 0, -8
     Health:
-        HP: 940
+        HP: 800
     RevealsShroud:
         Range: 5c0
     RallyPoint:
@@ -476,7 +476,7 @@ GAHPAD:
         Footprint: xx xx
         Dimensions: 2,2
     Health:
-        HP: 960
+        HP: 800
     RevealsShroud:
         Range: 5c0
     Exit@1:
@@ -542,7 +542,7 @@ GAHPAD:
 GADEPT:
     Inherits: ^Building
     Valued:
-        Cost: 500
+        Cost: 750
     Tooltip:
         Name: Service Depot
     Buildable:
@@ -556,7 +556,7 @@ GADEPT:
     Selectable:
         Bounds: 98, 68, -6, -6
     Health:
-        HP: 1800
+        HP: 1200
     RevealsShroud:
         Range: 5c0
     Reservable:
@@ -664,7 +664,7 @@ GADROP:
         BuildLimit: 1
         Description: Provides access to GDI's strongest arsenal.\n\nSpecial:\n- Allows calling a Poseidon drop (Steel Talons)\n- Allows calling a Titan drop (Steel Talons)
     Valued:
-        Cost: 3000
+        Cost: 2000
     Tooltip:
         Name: Steel Talon Dropship-Bay
     Building:

--- a/rules/gdi-support.yaml
+++ b/rules/gdi-support.yaml
@@ -440,7 +440,7 @@ GAMORTAR:
     DisabledOverlay:
     RequiresPower:
     Health:
-        HP: 2000
+        HP: 1000
     RevealsShroud:
         Range: 8c0
     BodyOrientation:

--- a/rules/gdi-vehicles.yaml
+++ b/rules/gdi-vehicles.yaml
@@ -201,7 +201,8 @@ SMECH:
         DefaultAttackSequence: shoot
 
 VULTURE:
-    Inherits: ^Walker
+    Inherits@1: ^Walker
+    Inherits@2: ^MediumVehicle
     Valued:
         Cost: 600
     Tooltip:
@@ -271,7 +272,7 @@ GTMTNK:
     Buildable:
         Queue: Vehicle.GDI
         BuildPaletteOrder: 105
-        Prerequisites: ~gaweap, ~!upgrade.st, ~!upgrade.zc
+        Prerequisites: ~gaweap, ~!upgrade.st
         Description: Well balanced main battle tank armed with a 90mm cannon and a coaxial MG.\n\nGood vs: Vehicles\n\nSpecial:\n- Crush class: Medium vehicle
     Voiced:
         VoiceSet: Archon
@@ -322,7 +323,7 @@ GTHTNK:
         VoiceSet: Predator
         Volume: 2
     Mobile:
-        Speed: 50
+        Speed: 55
         TurnSpeed: 3
     Health:
         HP: 1600

--- a/rules/nod-infantry.yaml
+++ b/rules/nod-infantry.yaml
@@ -121,7 +121,7 @@ CHAMSPY:
     Mobile:
         Speed: 50
     RevealsShroud:
-        Range: 12c0
+        Range: 10c0
     AttackFrontal:
     -ProducibleWithLevel:
     Infiltrates:

--- a/rules/nod-structures.yaml
+++ b/rules/nod-structures.yaml
@@ -264,7 +264,7 @@ NAHAND:
     Selectable:
         Bounds: 116, 78, 3, -8
     Health:
-        HP: 940
+        HP: 800
     RevealsShroud:
         Range: 5c0
     Exit:
@@ -357,7 +357,7 @@ NAWEAP:
         EffectImage: dig
         EffectPalette: player
         EffectSequence: idle
-        ChargeTime: 180
+        ChargeTime: 240
         SelectTargetSpeechNotification: SelectTarget
         LowPowerSpeechNotification: LowPower
         LaunchSpeechNotification: Reinforce
@@ -424,26 +424,6 @@ NARADR:
     DetectCloaked:
         Range: 15c0
         CloakTypes: Underground
-    ParatroopersPower@techcarry:
-        UnitType: valkyrie.support
-        Prerequisites: ~technology
-        DropItems: shadow,shadow,shadow,shadow,shadow
-        Icon: valkyrie
-        OrderName: ShadowTrooperInfantryDropOrder
-        SquadSize: 1
-        ChargeTime: 180
-        Description: Shadow Trooper Drop
-        LongDesc: Drops a special infantry taskforce on the field.
-        SelectTargetSpeechNotification: SelectTarget
-        LowPowerSpeechNotification: LowPower
-        LaunchSpeechNotification: Reinforce
-        DisplayBeacon: true
-        DisplayRadarPing: True
-        BeaconPoster: valkyrie
-        ArrowSequence: arrow
-        CircleSequence: circles
-        ClockSequence: clock
-        #BeaconPosterPalette: iconclock
     GrantExternalConditionPower@frenzy:
         Description: Frenzy
         LongDesc: Grants friendly infantry a time limited boost in attack and movement speed.
@@ -456,7 +436,7 @@ NARADR:
         Condition: fenzy
         OnFireSound: nod1_s5.aud
         Sequence: idle
-        ChargeTime: 180
+        ChargeTime: 210
         Prerequisites: ~propaganda
         ArrowSequence: arrow
         CircleSequence: circles
@@ -464,7 +444,29 @@ NARADR:
         #BeaconPosterPalette: iconclock
         Range: 8
         Duration: 450
-    
+    AirstrikePower@orcascout:
+        OrderName: Radar Vision
+        Prerequisites: naradr
+        Icon: orcascout
+        ChargeTime: 180
+        Description: Radar Vision
+        LongDesc: Reveals an area of the map and cloaked enemy units.
+        SelectTargetSound: orca_m12.aud
+        EndChargeSound: orca_s10.aud
+        LaunchSound: orca_a10.aud
+        CameraActor: camera.orcascout
+        CameraRemoveDelay: 300
+        UnitType: orca_g
+        SquadSize: 3
+        SquadOffset: -3072,3072,0
+        QuantizedFacings: 8
+        DisplayBeacon: true
+        DisplayRadarPing: True
+        BeaconPoster: orcascout
+        ArrowSequence: arrow
+        CircleSequence: circles
+        ClockSequence: clock
+        
 NAHPAD:
     Inherits: ^Building
     Valued:
@@ -480,7 +482,7 @@ NAHPAD:
         Footprint: xx xx
         Dimensions: 2,2
     Health:
-        HP: 940
+        HP: 800
     RevealsShroud:
         Range: 5c0
     Exit@1:
@@ -577,7 +579,27 @@ NAHPAD:
         ArrowSequence: arrow
         CircleSequence: circles
         ClockSequence: clock
- 
+    ParatroopersPower@techcarry:
+        UnitType: valkyrie.support
+        Prerequisites: ~technology
+        DropItems: shadow,shadow,shadow,shadow,shadow
+        Icon: valkyrie
+        OrderName: ShadowTrooperInfantryDropOrder
+        SquadSize: 1
+        ChargeTime: 180
+        Description: Shadow Trooper Drop
+        LongDesc: Drops a special infantry taskforce on the field.
+        SelectTargetSpeechNotification: SelectTarget
+        LowPowerSpeechNotification: LowPower
+        LaunchSpeechNotification: Reinforce
+        DisplayBeacon: true
+        DisplayRadarPing: True
+        BeaconPoster: valkyrie
+        ArrowSequence: arrow
+        CircleSequence: circles
+        ClockSequence: clock
+        #BeaconPosterPalette: iconclock
+        
 NAPYRA:
     Inherits: ^Building
     Buildable:

--- a/rules/nod-tech.yaml
+++ b/rules/nod-tech.yaml
@@ -44,7 +44,7 @@ upgrade.industry.tiblaser:
         Prerequisites: ~industry, napyra, ~!upgrade.tiblaser
         Queue: Tech.Nod
         BuildLimit: 1
-        Description:  Improves the damage of following units and buildings and causes them to create visceroids:\n- Hydra (Tiberium Laser + Tiberium AG Rockets)\n- Raven (Tiberium Rockets)\n- Gorran (Tiberium AG Rockets)\n- Hailstorm (Tibeirum Rockets)\n- Laser Turret (Tiberium Laser)\n- Obelisk of Light (Tiberium Laser)
+        Description:  Improves the weapon of following units and buildings and causes them to create visceroids:\n- Hydra (Tiberium Laser + Tiberium AG Rockets)\n- Raven (Tiberium Rockets)\n- Gorran (Tiberium AG Rockets)\n- Hailstorm (Tibeirum Rockets)\n- Laser Turret (Tiberium Laser)\n- Obelisk of Light (Tiberium Laser)
     Valued:
         Cost: 2000
     RenderSprites:

--- a/weapons/gdi-weapons.yaml
+++ b/weapons/gdi-weapons.yaml
@@ -91,8 +91,6 @@ DiscThrowerGun:
     Warhead@1Dam: SpreadDamage
         Spread: 0c256
         Damage: 100
-        Versus:
-            Building: 145
     Warhead@2Eff: CreateEffect
         Explosions: phosexp1, phosexp2, phosexp3, phosexp4, phosexp5, phosexp6
         ExplosionPalette: apolra2
@@ -836,7 +834,7 @@ WolverineGun:
 VultureGat:
     Inherits: ^Bullet 
 	Inherits@wh: ^BulletWH  
-    ReloadDelay: 150
+    ReloadDelay: 85
     Range: 6c0
     Report: mgfire.aud
     Burst: 16
@@ -1301,8 +1299,9 @@ HornetMissileAA:
 SAMMissile:
     Inherits: ^MissileAPHE 
 	Inherits@wh: ^APHEWH
-    ReloadDelay: 68
+    ReloadDelay: 50
     Burst: 2
+    BurstDelay: 10
     Range: 8c0
     Report: launcher01.aud, launcher02.aud, launcher03.aud, launcher04.aud
     ValidTargets: Air, MidAir, HighAir

--- a/weapons/nod-weapons.yaml
+++ b/weapons/nod-weapons.yaml
@@ -290,11 +290,11 @@ RocketeerGunAA:
     
 NodHarvGun:
     Inherits: AcolyteGun
-    ReloadDelay: 15
+    ReloadDelay: 50
     Range: 5c0
-    -Burst:
+    Burst: 2
     Warhead@1Dam: SpreadDamage
-        Damage: 50
+        Damage: 30
 
 SpecterGun:
     Inherits: ^ShellHE 
@@ -1332,7 +1332,7 @@ ShadowTrooperLaser:
 LaserTurretTibLaser:
     Inherits: ^BasicLaser
     Inherits@wh: ^TiberiumWH
-    ReloadDelay: 45
+    ReloadDelay: 55
     Range: 8c512
     Report: bigggun1.aud
     ValidTargets: Ground
@@ -1346,7 +1346,7 @@ LaserTurretTibLaser:
         SecondaryBeamZOffset: 2047
         SecondaryBeamColor: 00FF00
     Warhead@1Dam: SpreadDamage
-        Spread: 42
+        Spread: 128
         Damage: 200
     Warhead@2Eff: CreateEffect
         Explosions: protonexpl_tiny
@@ -1412,7 +1412,7 @@ PhantomLaser:
 LaserTurretLaserUpgraded:
     Inherits: LaserTurretLaser
     Range: 8c512
-    ReloadDelay: 35
+    ReloadDelay: 55
     Projectile: LaserZap
         Color: C80000
         Width: 55
@@ -2008,8 +2008,17 @@ HydraGasMissiles:
         
 SAMSiteMissile:
     Inherits: RedEye
+    ReloadDelay: 75
     Burst: 3
     BurstDelay: 10
+    Warhead@1Dam: SpreadDamage
+        Spread: 0c512
+        Damage: 150
+        ValidTargets: Air, MidAir, HighAir
+    Warhead@2Eff: CreateEffect
+        Explosions: tiny_tumu
+        ExplosionPalette: apolra50alpha
+        ImpactSounds: expnew12.aud, explosion01.aud, explosion02.aud
         
 BlackHandFlamer:
     Inherits: FireballLauncher

--- a/weapons/shared-weapons.yaml
+++ b/weapons/shared-weapons.yaml
@@ -50,7 +50,7 @@ UnitExplodeEpic:
         
 PyradonExplosion:
     Warhead@1Dam: SpreadDamage
-        Spread: 512
+        Spread: 768
         Damage: 500
         Versus:
             Infantry: 100
@@ -226,8 +226,8 @@ TiberiumExplosionSilo:
         
 SmallTiberiumExplosion:
     Warhead@1Dam: SpreadDamage
-        Spread: 1c0
-        Damage: 150
+        Spread: 0c512
+        Damage: 100
         Versus:
             Infantry: 100
             Cyborg: 100
@@ -248,8 +248,8 @@ SmallTiberiumExplosion:
         
 LargeTiberiumExplosion:
     Warhead@1Dam: SpreadDamage
-        Spread: 2c0
-        Damage: 200
+        Spread: 1c0
+        Damage: 150
         Versus:
             Infantry: 100
             Cyborg: 100


### PR DESCRIPTION
Global:
Revealsshroud of Scout, Informer and Chameleon Spy from 12c0 to 10c0
Cabal Power Plant to 1200 HP
All Barracks to 800 HP
All Helipads to 800 HP
Changed the mode units attacking buildings automatically: only defenses and units are now attacked automatically
Reduced Harvester explosion range: SmalTiberiumExplosion spread from 1c0 to 0c512 and damage from 150 to 100, LargeTiberiumExplosion spread from 2c0 to 1c0 and damage from 200 to 150
Changed value of Tiberium Fiend critter from 1$ to 300$

GDI:
Service Depot: HP from 1800 to 1200, cost from 500$ to 750$
Howitzer Tower HP nerf from 2000 to 1000
Steel Talon-Dropshipbay from 3000$ to 2000$
Disc Thrower: from 300$ to 250$, removed the extra building damage buff
Vulture: VultureGat reloaddelay from 150 to 85
SAM Tower: reloaddelay from 68 to 50, added Burstdelay of 10
ZOCOM: Archon Tank now available
Grizzly Tank: movementspeed from 50 to 55

Nod:
New Ability: Radar Vision Support Power Placeholder
Tiberium Laser Turret spread from 42 to 128
SAM Site: reloaddelay from 55 to 75, damage from 200 to 150
Industry Nod Harvester NodHarvGun: Reloaddelay from 15 to 50, Burst from 0 to 2, damage from 50 to 30
Pyradon Tank: PyradonExplosion spread from 512 to 768
Support Power Subterranean Ambush cooldown from 3:00 to 4:00
Shadow Trooper Drop Support Power from Radar to Helipad
Frenzy Support Power cooldown drom 3:00 to 3:30

Cabal:
Helion: chargedelay from 10 to 300
Cyborg Enhancement Center Energy cost from 200 to 300
Cannon Husk Tooltip changed to: good against ground targets
Fixed repair aoe visual for Golem on Cyborgs