### PR TITLE
Eco/Harv/Ref changes

### DIFF
--- a/rules/cabal-structures.yaml
+++ b/rules/cabal-structures.yaml
@@ -136,7 +136,7 @@ KPROC:
 	Selectable:
 		Bounds: 134, 122, 0, -18
 	Health:
-		HP: 1500
+		HP: 2000
 	RevealsShroud:
 		Range: 8c497
 	TiberianSunRefinery:

--- a/rules/cabal-vehicles.yaml
+++ b/rules/cabal-vehicles.yaml
@@ -80,7 +80,7 @@ KHARV:
 		BaleLoadDelay: 12
 		BaleUnloadDelay: 6
 		SearchFromProcRadius: 36
-		SearchFromOrderRadius: 18
+		SearchFromOrderRadius: 20
 		HarvestVoice: Action
 		DeliverVoice: Move
 		PipCount: 7
@@ -102,7 +102,7 @@ KHARV:
 			Veins: 100
 	-DamagedByTerrain@Veins:
 	Health:
-		HP: 1200
+		HP: 1500
 	RevealsShroud:
 		Range: 8c497
 	RenderSprites:

--- a/rules/forgotten-structures.yaml
+++ b/rules/forgotten-structures.yaml
@@ -122,7 +122,7 @@ FPROC:
 		Prerequisites: anypower, ~structures.forgotten
 		Description: Processes raw Tiberium into useable resources. \n\nStores 700$.
 	Valued:
-		Cost: 1500
+		Cost: 2000
 	Tooltip:
 		Name: Forgotten Refinery
 	Building:

--- a/rules/forgotten-vehicles.yaml
+++ b/rules/forgotten-vehicles.yaml
@@ -67,17 +67,28 @@ FHARV:
 		BaleLoadDelay: 12
 		BaleUnloadDelay: 6
 		SearchFromProcRadius: 36
-		SearchFromOrderRadius: 18
+		SearchFromOrderRadius: 20
 		HarvestVoice: Action
 		DeliverVoice: Move
 		PipCount: 7
 	Mobile:
 		Speed: 71
 		TerrainSpeeds:
+			Clear: 100
+			Road: 100
+			Bridge: 100
+			Rail: 100
+			DirtRoad: 100
+			Rough: 100
+			Green: 100
 			Tiberium: 100
+			BlueTiberium: 100
+			RedTiberium: 100
+			PurpleTiberium: 100
+			Veins: 100
 	-DamagedByTerrain@Veins:
 	Health:
-		HP: 1200
+		HP: 1500
 	RevealsShroud:
 		Range: 8c497
 	RenderSprites:

--- a/rules/gdi-structures.yaml
+++ b/rules/gdi-structures.yaml
@@ -150,7 +150,7 @@ GPROC:
 	Selectable:
 		Bounds: 134, 122, 0, -18
 	Health:
-		HP: 1500
+		HP: 2000
 	RevealsShroud:
 		Range: 8c497
 	TiberianSunRefinery:

--- a/rules/gdi-vehicles.yaml
+++ b/rules/gdi-vehicles.yaml
@@ -62,17 +62,28 @@ GHARV:
 		BaleLoadDelay: 12
 		BaleUnloadDelay: 6
 		SearchFromProcRadius: 36
-		SearchFromOrderRadius: 18
+		SearchFromOrderRadius: 20
 		HarvestVoice: Action
 		DeliverVoice: Move
 		PipCount: 7
 	Mobile:
 		Speed: 71
 		TerrainSpeeds:
+			Clear: 100
+			Road: 100
+			Bridge: 100
+			Rail: 100
+			DirtRoad: 100
+			Rough: 100
+			Green: 100
 			Tiberium: 100
+			BlueTiberium: 100
+			RedTiberium: 100
+			PurpleTiberium: 100
+			Veins: 100
 	-DamagedByTerrain@Veins:
 	Health:
-		HP: 1500
+		HP: 1800
 	RevealsShroud:
 		Range: 8c497
 	RenderSprites:

--- a/rules/nod-structures.yaml
+++ b/rules/nod-structures.yaml
@@ -154,7 +154,7 @@ NIPROC:
 	Inherits: ^BuildingInfiltrate
 	Inherits@2: ^3x3hitshapewithyoffset
 	Valued:
-		Cost: 1500
+		Cost: 2000
 	Tooltip:
 		Name: Nod Industry Tiberium Refinery
 	Buildable:

--- a/rules/nod-vehicles.yaml
+++ b/rules/nod-vehicles.yaml
@@ -63,7 +63,7 @@ NIHARV:
 		BaleLoadDelay: 12
 		BaleUnloadDelay: 6
 		SearchFromProcRadius: 36
-		SearchFromOrderRadius: 18
+		SearchFromOrderRadius: 20
 		HarvestVoice: Action
 		DeliverVoice: Move
 		PipCount: 7
@@ -71,9 +71,20 @@ NIHARV:
 	Mobile:
 		Speed: 71
 		TerrainSpeeds:
+			Clear: 100
+			Road: 100
+			Bridge: 100
+			Rail: 100
+			DirtRoad: 100
+			Rough: 100
+			Green: 100
 			Tiberium: 100
+			BlueTiberium: 100
+			RedTiberium: 100
+			PurpleTiberium: 100
+			Veins: 100
 	Health:
-		HP: 1200
+		HP: 1500
 	Armament@primary:
 		Weapon: NodHarvGun
 		MuzzleSequence: muzzle
@@ -124,7 +135,7 @@ NTHARV:
 		BaleLoadDelay: 12
 		BaleUnloadDelay: 6
 		SearchFromProcRadius: 36
-		SearchFromOrderRadius: 18
+		SearchFromOrderRadius: 20
 		HarvestVoice: Action
 		DeliverVoice: Move
 		PipCount: 7
@@ -132,9 +143,20 @@ NTHARV:
 	Mobile:
 		Speed: 71
 		TerrainSpeeds:
+			Clear: 100
+			Road: 100
+			Bridge: 100
+			Rail: 100
+			DirtRoad: 100
+			Rough: 100
+			Green: 100
 			Tiberium: 100
+			BlueTiberium: 100
+			RedTiberium: 100
+			PurpleTiberium: 100
+			Veins: 100
 	Health:
-		HP: 1200
+		HP: 1500
 	GrantConditionOnPrerequisite@cloak:
 		Condition: technology
 		Prerequisites: technology
@@ -179,7 +201,7 @@ NPHARV:
 		BaleLoadDelay: 12
 		BaleUnloadDelay: 6
 		SearchFromProcRadius: 36
-		SearchFromOrderRadius: 18
+		SearchFromOrderRadius: 20
 		HarvestVoice: Action
 		DeliverVoice: Move
 		PipCount: 7
@@ -189,9 +211,20 @@ NPHARV:
 	Mobile:
 		Speed: 71
 		TerrainSpeeds:
+			Clear: 100
+			Road: 100
+			Bridge: 100
+			Rail: 100
+			DirtRoad: 100
+			Rough: 100
+			Green: 100
 			Tiberium: 100
+			BlueTiberium: 100
+			RedTiberium: 100
+			PurpleTiberium: 100
+			Veins: 100
 	Health:
-		HP: 1200
+		HP: 1500
 	RevealsShroud:
 		Range: 8c497
 	-ProducibleWithLevel:

--- a/rules/world.yaml
+++ b/rules/world.yaml
@@ -58,7 +58,7 @@
 		EditorSprite: waypoint
 		Sequences: tib01, tib02, tib03, tib04, tib05, tib06, tib07, tib08, tib09, tib10, tib11, tib12, tib13, tib14, tib15, tib16, tib17, tib18, tib19, tib20
 		MaxDensity: 12
-		ValuePerUnit: 50
+		ValuePerUnit: 40
 		AllowedTerrainTypes: Clear, Rough, DirtRoad, Green
 		AllowUnderActors: True
 		AllowUnderBuildings: True
@@ -72,7 +72,7 @@
 		EditorSprite: waypoint
 		Sequences: tib01, tib02, tib03, tib04, tib05, tib06, tib07, tib08, tib09, tib10, tib11, tib12, tib13, tib14, tib15, tib16, tib17, tib18, tib19, tib20
 		MaxDensity: 12
-		ValuePerUnit: 100
+		ValuePerUnit: 80
 		AllowedTerrainTypes: Clear, Rough, DirtRoad, Green
 		AllowUnderActors: True
 		AllowUnderBuildings: True
@@ -100,7 +100,7 @@
 		EditorSprite: waypoint
 		Sequences: tib01, tib02, tib03, tib04, tib05, tib06, tib07, tib08, tib09, tib10, tib11, tib12, tib13, tib14, tib15, tib16, tib17, tib18, tib19, tib20
 		MaxDensity: 12
-		ValuePerUnit: 10
+		ValuePerUnit: 30
 		AllowedTerrainTypes: Clear, Rough, DirtRoad, Green
 		AllowUnderActors: True
 		AllowUnderBuildings: True
@@ -114,7 +114,7 @@
 		EditorSprite: waypoint
 		Sequences: tib01, tib02, tib03, tib04, tib05, tib06, tib07, tib08, tib09, tib10, tib11, tib12, tib13, tib14, tib15, tib16, tib17, tib18, tib19, tib20
 		MaxDensity: 12
-		ValuePerUnit: 200
+		ValuePerUnit: 140
 		AllowedTerrainTypes: Clear, Rough, DirtRoad, Green
 		AllowUnderActors: True
 		AllowUnderBuildings: True


### PR DESCRIPTION
Eco changes (20% less income)
Refinery HP for all faction buffed to 2000 (1500 before)
Harvester scan radius adjusted and terrianspeed fixed.
Harvester HP increased for all faction (+300)