### PR TITLE
Ganonpatch

### DIFF
--- a/rules/cabal-tech.yaml
+++ b/rules/cabal-tech.yaml
@@ -1,7 +1,7 @@
 upgrade.hc:
 	Inherits: ^BuildingPlug
 	Tooltip:
-		Name: Advanced Platings
+		Name: Fullerene Construction Techniques
 	Buildable:
 		BuildPaletteOrder: 300
 		Prerequisites: ~kabtech
@@ -17,7 +17,7 @@ upgrade.hc:
 upgrade.lc:
 	Inherits: ^BuildingPlug
 	Tooltip:
-		Name: Alloyed Chassis
+		Name: Cybernetic Legs
 	Buildable:
 		BuildPaletteOrder: 301
 		Prerequisites: ~kabtech
@@ -33,7 +33,7 @@ upgrade.lc:
 upgrade.visionuplink:
 	Inherits: ^BuildingPlug
 	Tooltip:
-		Name: Vision Uplink
+		Name: Optics Augmentation
 	Buildable:
 		BuildPaletteOrder: 302
 		Prerequisites: ~kabtech
@@ -65,7 +65,7 @@ upgrade.photonreactors:
 upgrade.teleporter:
 	Inherits: ^BuildingPlug
 	Tooltip:
-		Name: Teleporter
+		Name: Experimental Phase Jump
 	Buildable:
 		BuildPaletteOrder: 304
 		Prerequisites: ~kabtech

--- a/rules/gdi-aircraft.yaml
+++ b/rules/gdi-aircraft.yaml
@@ -61,7 +61,7 @@ ORCA_F2:
 	Inherits@FeatureAutotargetInfantry: ^FeatureAutotargetInfantry2
 	Inherits@FeatureAutotargetBuilding: ^FeatureAutotargetBuilding3
 	Valued:
-		Cost: 1200
+		Cost: 1350
 	Tooltip:
 		Name: Orca F-2
 	Buildable:
@@ -419,7 +419,7 @@ ARTILLERY_BEACON:
 		CruiseAltitude: 28c291
 		IdealSeparation: 1c424
 		TurnSpeed: 3
-		Speed: 424
+		Speed: 150
 	Health:
 		HP: 2000
 	RevealsShroud:
@@ -629,7 +629,7 @@ CONDOR:
 		Volume: 2
 	Aircraft:
 		TurnSpeed: 4
-		Speed: 200
+		Speed: 220
 		CruiseAltitude: 11c321
 	Health:
 		HP: 1100
@@ -888,7 +888,7 @@ Hellfire_beacon:
 		CruiseAltitude: 20c291
 		IdealSeparation: 1c424
 		TurnSpeed: 3
-		Speed: 64
+		Speed: 150
 	Health:
 		HP: 2000
 	RevealsShroud:

--- a/rules/gdi-infantry.yaml
+++ b/rules/gdi-infantry.yaml
@@ -316,7 +316,7 @@ ZMARINE:
 		Prerequisites: ~gapile, ~!t1, ~upgrade.zc
 		Description: ZOCOM's variant of the Marine.\n\nGood vs: Infantry\n\nSpecial:\n- Immune to Tiberium radiation\n- Crush class: Light Infantry
 	Valued:
-		Cost: 200
+		Cost: 175
 	Tooltip:
 		Name: Zone Marine
 	Selectable:
@@ -462,10 +462,16 @@ ZCOMMANDO:
 	Inherits@FeatureAutotargetVehicle: ^FeatureAutotargetVehicle1
 	Inherits@FeatureAutotargetInfantry: ^FeatureAutotargetInfantry1
 	Inherits@FeatureAutotargetBuilding: ^FeatureAutotargetBuilding2
-	Valued:
-		Cost: 2000
+	Buildable:
+		Queue: Infantry.GDI
+		BuildPaletteOrder: 110
+        BuildLimit: 1
+		Prerequisites: ~gapile, gatech, ~!t1, ~!t2, ~upgrade.zc
+		Description: Colonel Mobius is one of the most famous GDI commanders.\nHe is armed with a Railgunshotgun.\n\nGood vs: Ground\n\nSpecial:\n- Stealth Detection\n- Selfhealing\n- Immune to Tiberium radiation\n- Crush class: Heavy infantry
+    Valued:
+		Cost: 4000
 	Tooltip:
-		Name: Zone Commander
+		Name: Colonel Mobius
 	Selectable:
 		Bounds: 24,34,0,-9
 	Voiced:
@@ -514,9 +520,16 @@ ZCOMMANDO:
 		MuzzlePalette: effect50alpha
 	AttackFrontal:
 	WithMuzzleOverlay:
+    SelfHealing:
+		Step: 2
+		PercentageStep: 0
+		Delay: 1
+		HealIfBelow: 100
+		DamageCooldown: 200
 	DetectCloaked:
 		Range: 8c497
 	RenderDetectionCircle:
 	SoundOnDamageTransition:
 		DamagedSounds: trooper_f1.aud, trooper_f2.aud, trooper_f3.aud
-	HitShape:
+	-Crushable:
+    HitShape:

--- a/rules/gdi-infantry.yaml
+++ b/rules/gdi-infantry.yaml
@@ -465,10 +465,10 @@ ZCOMMANDO:
 	Buildable:
 		Queue: Infantry.GDI
 		BuildPaletteOrder: 110
-        BuildLimit: 1
+		BuildLimit: 1
 		Prerequisites: ~gapile, gatech, ~!t1, ~!t2, ~upgrade.zc
 		Description: Colonel Mobius is one of the most famous GDI commanders.\nHe is armed with a Railgunshotgun.\n\nGood vs: Ground\n\nSpecial:\n- Stealth Detection\n- Selfhealing\n- Immune to Tiberium radiation\n- Crush class: Heavy infantry
-    Valued:
+	Valued:
 		Cost: 4000
 	Tooltip:
 		Name: Colonel Mobius
@@ -520,7 +520,7 @@ ZCOMMANDO:
 		MuzzlePalette: effect50alpha
 	AttackFrontal:
 	WithMuzzleOverlay:
-    SelfHealing:
+	SelfHealing:
 		Step: 2
 		PercentageStep: 0
 		Delay: 1
@@ -532,4 +532,4 @@ ZCOMMANDO:
 	SoundOnDamageTransition:
 		DamagedSounds: trooper_f1.aud, trooper_f2.aud, trooper_f3.aud
 	-Crushable:
-    HitShape:
+	HitShape:

--- a/rules/gdi-structures.yaml
+++ b/rules/gdi-structures.yaml
@@ -626,7 +626,7 @@ GATECH:
 		Queue: Building.GDI
 		BuildPaletteOrder: 110
 		Prerequisites: anypower, garadr, gaarmory, ~structures.gdi
-		Description: Provides access to advanced GDI technologies.\n\nSpecial:\n- Allows calling a Zone Commander squad (ZOCOM)
+		Description: Provides access to advanced GDI technologies.\n\nSpecial:\n- Allows calling a Grizzly Tank Drop (GDF)\n- Allows calling a Titan drop (Steel Talons)\n- Allows calling a Zone Team Drop (ZOCOM)
 	Valued:
 		Cost: 4000
 	Tooltip:
@@ -656,8 +656,8 @@ GATECH:
 		SquadSize: 1
 		ChargeTime: 300
 		QuantizedFacings: 2
-		Description: Zone Troop Drop
-		LongDesc: Drops a Zone Commander with a squad of 2 Troopers and 2 Raiders.
+		Description: Zone Team Call
+		LongDesc: Drops a squad of 3 Troopers and 3 Raiders.
 		SelectTargetSpeechNotification: SelectTarget
 		LowPowerSpeechNotification: LowPower
 		LaunchSpeechNotification: Reinforce
@@ -687,6 +687,25 @@ GATECH:
 		ArrowSequence: arrow
 		CircleSequence: circles
 		ClockSequence: clock
+	ParatroopersPower@titans:
+		UnitType: dshp.support
+		DropItems: mmch, mmch, mmch, mmch
+		Icon: titan
+		OrderName: TitanDropOrder
+		SquadSize: 1
+		ChargeTime: 330
+		QuantizedFacings: 2
+		Description: Titan Mech Drop
+		LongDesc: Drops 4 Titans on the battlefield.
+		SelectTargetSpeechNotification: SelectTarget
+		LowPowerSpeechNotification: LowPower
+		LaunchSpeechNotification: Reinforce
+		DisplayBeacon: true
+		DisplayRadarPing: True
+		BeaconPoster: titan
+		ArrowSequence: arrow
+		CircleSequence: circles
+		ClockSequence: clock
 
 GADROP:
 	Inherits: ^Building
@@ -697,7 +716,7 @@ GADROP:
 		BuildPaletteOrder: 111
 		Prerequisites: anypower, gatech, gaarmory, ~structures.gdi, ~upgrade.st
 		BuildLimit: 1
-		Description: Provides access to GDI's strongest arsenal.\n\nSpecial:\n- Allows calling a Poseidon drop (Steel Talons)\n- Allows calling a Titan drop (Steel Talons)
+		Description: Provides access to GDI's strongest arsenal.\n\nSpecial:\n- Allows calling a Kodiak Battleship
 	Valued:
 		Cost: 2000
 	Tooltip:
@@ -738,25 +757,6 @@ GADROP:
 	WithIdleOverlay@LIGHTS:
 		Sequence: idle-lights
 	ProvidesPrerequisite@buildingname:
-	ParatroopersPower@titans:
-		UnitType: dshp.support
-		DropItems: mmch, mmch, mmch, mmch
-		Icon: titan
-		OrderName: TitanDropOrder
-		SquadSize: 1
-		ChargeTime: 330
-		QuantizedFacings: 2
-		Description: Titan Mech Drop
-		LongDesc: Drops 4 Titans on the battlefield.
-		SelectTargetSpeechNotification: SelectTarget
-		LowPowerSpeechNotification: LowPower
-		LaunchSpeechNotification: Reinforce
-		DisplayBeacon: true
-		DisplayRadarPing: True
-		BeaconPoster: titan
-		ArrowSequence: arrow
-		CircleSequence: circles
-		ClockSequence: clock
 	AirstrikePower@HellfireMissilesStrikePower:
 		Prerequisites: garadr, upgrade.st
 		Icon: kodiak
@@ -778,3 +778,4 @@ GADROP:
 		ArrowSequence: arrow
 		CircleSequence: circles
 		ClockSequence: clock
+

--- a/rules/gdi-structures.yaml
+++ b/rules/gdi-structures.yaml
@@ -466,27 +466,6 @@ GAARMORY:
 		ArrowSequence: arrow
 		CircleSequence: circles
 		ClockSequence: clock
-	AirstrikePower@HellfireMissilesStrikePower:
-		Prerequisites: garadr, upgrade.gdf
-		Icon: kodiak
-		OrderName: HellfireMissilesStrikePowerInfoOrder
-		ChargeTime: 360
-		QuantizedFacings: 2
-		Description: A huge Rocketbombardment
-		LongDesc: Deploy a bombardment of an Kodiak Battleship.\nVery effective vs buildings and light armored targets.
-		SelectTargetSound: predator_a8.aud
-		EndChargeSound: predator_m2.aud
-		LaunchSound: predator_a10.aud
-		IncomingSound: g_00-cd004.aud
-		UnitType: hellfire_beacon
-		SquadSize: 1
-		DisplayBeacon: True
-		BeaconPoster: kodiak
-		DisplayRadarPing: True
-		CameraActor: camera
-		ArrowSequence: arrow
-		CircleSequence: circles
-		ClockSequence: clock
 
 GAHPAD:
 	Inherits: ^Building
@@ -670,14 +649,14 @@ GATECH:
 	ProvidesPrerequisite@buildingname:
 	ParatroopersPower@zonecommander:
 		UnitType: dshp.support
-		DropItems: ztrooper, ztrooper, zcommando, zraider, zraider
+		DropItems: ztrooper, ztrooper, ztrooper, zraider, zraider, zraider
 		Prerequisites: gaarmory, ~upgrade.zc
 		Icon: zonecommando
 		OrderName: ZoneInfDropOrder
 		SquadSize: 1
 		ChargeTime: 300
 		QuantizedFacings: 2
-		Description: Zone Commander drop
+		Description: Zone Troop Drop
 		LongDesc: Drops a Zone Commander with a squad of 2 Troopers and 2 Raiders.
 		SelectTargetSpeechNotification: SelectTarget
 		LowPowerSpeechNotification: LowPower
@@ -685,6 +664,26 @@ GATECH:
 		DisplayBeacon: true
 		DisplayRadarPing: True
 		BeaconPoster: zonecommando
+		ArrowSequence: arrow
+		CircleSequence: circles
+		ClockSequence: clock
+	ParatroopersPower@poseidon:
+		UnitType: dshp.support
+		DropItems: gthtnk, gthtnk, gthtnk
+        Prerequisites: gaarmory, ~upgrade.gdf
+		Icon: poseidon
+		OrderName: PoseidonDropOrder
+		SquadSize: 1
+		ChargeTime: 300
+		QuantizedFacings: 2
+		Description: Grizzly Tank Drop
+		LongDesc: Drops 3 Grizzly Tanks on the battlefield.
+		SelectTargetSpeechNotification: SelectTarget
+		LowPowerSpeechNotification: LowPower
+		LaunchSpeechNotification: Reinforce
+		DisplayBeacon: true
+		DisplayRadarPing: True
+		BeaconPoster: poseidon
 		ArrowSequence: arrow
 		CircleSequence: circles
 		ClockSequence: clock
@@ -739,41 +738,43 @@ GADROP:
 	WithIdleOverlay@LIGHTS:
 		Sequence: idle-lights
 	ProvidesPrerequisite@buildingname:
-	ParatroopersPower@poseidon:
-		UnitType: dshp.support
-		DropItems: gthtnk, poseidon, gthtnk, gthtnk
-		Icon: poseidon
-		OrderName: PoseidonDropOrder
-		SquadSize: 1
-		ChargeTime: 300
-		QuantizedFacings: 2
-		Description: Poseidon tank drop
-		LongDesc: Drops a Steel Talon tank battalion on the field.
-		SelectTargetSpeechNotification: SelectTarget
-		LowPowerSpeechNotification: LowPower
-		LaunchSpeechNotification: Reinforce
-		DisplayBeacon: true
-		DisplayRadarPing: True
-		BeaconPoster: poseidon
-		ArrowSequence: arrow
-		CircleSequence: circles
-		ClockSequence: clock
 	ParatroopersPower@titans:
 		UnitType: dshp.support
-		DropItems: mmch, mmch2, mmch, mmch
+		DropItems: mmch, mmch, mmch, mmch
 		Icon: titan
 		OrderName: TitanDropOrder
 		SquadSize: 1
 		ChargeTime: 330
 		QuantizedFacings: 2
-		Description: Titan mech drop
-		LongDesc: Drops a Steel Talon mech battalion on the field.
+		Description: Titan Mech Drop
+		LongDesc: Drops 4 Titans on the battlefield.
 		SelectTargetSpeechNotification: SelectTarget
 		LowPowerSpeechNotification: LowPower
 		LaunchSpeechNotification: Reinforce
 		DisplayBeacon: true
 		DisplayRadarPing: True
 		BeaconPoster: titan
+		ArrowSequence: arrow
+		CircleSequence: circles
+		ClockSequence: clock
+	AirstrikePower@HellfireMissilesStrikePower:
+		Prerequisites: garadr, upgrade.st
+		Icon: kodiak
+		OrderName: HellfireMissilesStrikePowerInfoOrder
+		ChargeTime: 360
+		QuantizedFacings: 2
+		Description: Hellfire Missiles
+		LongDesc: Deploy a bombardment of an Kodiak Battleship.\nVery effective vs buildings and light armored targets.
+		SelectTargetSound: predator_a8.aud
+		EndChargeSound: predator_m2.aud
+		LaunchSound: predator_a10.aud
+		IncomingSound: g_00-cd004.aud
+		UnitType: hellfire_beacon
+		SquadSize: 1
+		DisplayBeacon: True
+		BeaconPoster: kodiak
+		DisplayRadarPing: True
+		CameraActor: camera
 		ArrowSequence: arrow
 		CircleSequence: circles
 		ClockSequence: clock

--- a/rules/gdi-structures.yaml
+++ b/rules/gdi-structures.yaml
@@ -670,7 +670,7 @@ GATECH:
 	ParatroopersPower@poseidon:
 		UnitType: dshp.support
 		DropItems: gthtnk, gthtnk, gthtnk
-        Prerequisites: gaarmory, ~upgrade.gdf
+		Prerequisites: gaarmory, ~upgrade.gdf
 		Icon: poseidon
 		OrderName: PoseidonDropOrder
 		SquadSize: 1

--- a/rules/gdi-vehicles.yaml
+++ b/rules/gdi-vehicles.yaml
@@ -112,7 +112,7 @@ APC:
 		Queue: Vehicle.GDI
 		BuildPaletteOrder: 103
 		Prerequisites: ~gaweap, ~!upgrade.st
-		Description: Armored infantry transport.\n\nGood vs: Infantry, Air\n\nSpecial:\n- Can transport infantry\n- Can attack air\n- Can swim on water\n- Crush class: Medium vehicle
+		Description: Armored infantry transport.\n\nGood vs: Infantry, Air\n\nSpecial:\n- Can transport infantry\n- Can attack air\n- Can swim on water\n- Stealth detection\n- Crush class: Medium vehicle
 	Voiced:
 		VoiceSet: Predator
 		Volume: 2
@@ -223,7 +223,7 @@ VULTURE:
 		Queue: Vehicle.GDI
 		BuildPaletteOrder: 104
 		Prerequisites: ~gaweap, ~!t1, ~upgrade.st
-		Description: Medium walker, armed with multipurpose missiles and gattling cannons.\n\nGood vs: Infantry, Air\n\nSpecial:\n- Can attack Air\n- Crush class: Medium vehicle
+		Description: Medium walker, armed with multipurpose missiles and gattling cannons.\n\nGood vs: Infantry, Air\n\nSpecial:\n- Can attack Air\n- Stealth detection\n- Crush class: Medium vehicle
 	Voiced:
 		VoiceSet: Vulture
 		Volume: 2
@@ -623,7 +623,7 @@ MMCH:
 		Interval: 16
 		RequiresCondition: walker
 	Health:
-		HP: 1440
+		HP: 1200
 	RevealsShroud:
 		Range: 12c745
 	BodyOrientation:
@@ -635,7 +635,7 @@ MMCH:
 	WithSpriteTurret:
 		Recoils: True
 	Armament:
-		Weapon: 122mmAP
+		Weapon: TitanAP
 		LocalOffset: 1188,458,1485
 		MuzzleSequence: muzzle
 		MuzzlePalette: apolra50alpha

--- a/rules/nod-aircraft.yaml
+++ b/rules/nod-aircraft.yaml
@@ -168,10 +168,10 @@ HYDRA:
 
 HAVOC:
 	Inherits: ^Helicopter
-    Inherits@FeatureTargettype: ^FeatureTargettypeAircraft
-    Inherits@FeatureAutotargetVehicle: ^FeatureAutotargetVehicle1
-    Inherits@FeatureAutotargetInfantry: ^FeatureAutotargetInfantry2
-    Inherits@FeatureAutotargetBuilding: ^FeatureAutotargetBuilding3
+	Inherits@FeatureTargettype: ^FeatureTargettypeAircraft
+	Inherits@FeatureAutotargetVehicle: ^FeatureAutotargetVehicle1
+	Inherits@FeatureAutotargetInfantry: ^FeatureAutotargetInfantry2
+	Inherits@FeatureAutotargetBuilding: ^FeatureAutotargetBuilding3
 	Valued:
 		Cost: 2500
 	Tooltip:
@@ -285,8 +285,8 @@ NODCARRY:
 
 NODCARRY.SUPPORT:
 	Inherits: NODCARRY
-    -Targetable@Targettype:
-    -Targetable@TargettypeGrounded:
+	-Targetable@Targettype:
+	-Targetable@TargettypeGrounded:
 	-Buildable:
 	Valued:
 		Cost: 650

--- a/rules/nod-aircraft.yaml
+++ b/rules/nod-aircraft.yaml
@@ -73,7 +73,7 @@ HYDRA:
 	Inherits@FeatureAutotargetInfantry: ^FeatureAutotargetInfantry2
 	Inherits@FeatureAutotargetBuilding: ^FeatureAutotargetBuilding3
 	Valued:
-		Cost: 1400
+		Cost: 1650
 	Tooltip:
 		Name: Hydra
 	Buildable:
@@ -168,9 +168,10 @@ HYDRA:
 
 HAVOC:
 	Inherits: ^Helicopter
-	Inherits@FeatureAutotargetVehicle: ^FeatureAutotargetVehicle1
-	Inherits@FeatureAutotargetInfantry: ^FeatureAutotargetInfantry2
-	Inherits@FeatureAutotargetBuilding: ^FeatureAutotargetBuilding3
+    Inherits@FeatureTargettype: ^FeatureTargettypeAircraft
+    Inherits@FeatureAutotargetVehicle: ^FeatureAutotargetVehicle1
+    Inherits@FeatureAutotargetInfantry: ^FeatureAutotargetInfantry2
+    Inherits@FeatureAutotargetBuilding: ^FeatureAutotargetBuilding3
 	Valued:
 		Cost: 2500
 	Tooltip:
@@ -284,6 +285,8 @@ NODCARRY:
 
 NODCARRY.SUPPORT:
 	Inherits: NODCARRY
+    -Targetable@Targettype:
+    -Targetable@TargettypeGrounded:
 	-Buildable:
 	Valued:
 		Cost: 650

--- a/rules/nod-infantry.yaml
+++ b/rules/nod-infantry.yaml
@@ -12,7 +12,7 @@ NASOL:
 		Prerequisites: ~nahand, ~!upgrade.mass, ~!technology
 		Description: Nod's basic combat infantry.\n\nGood vs: Infantry\n\nSpecial:\n- Tiberium Infusion (Industry)\n- Mass Recruitment (Propaganda)\n- Nanofiber Armor (Propaganda)\n- Crush class: Light Infantry
 	Valued:
-		Cost: 60
+		Cost: 70
 	Tooltip:
 		Name: Rookie
 	Selectable:
@@ -49,7 +49,7 @@ NASOL2:
 	RenderSprites:
 		Image: NASOL
 	Valued:
-		Cost: 30
+		Cost: 35
 
 E3:
 	Inherits@1: ^Soldier

--- a/rules/nod-structures.yaml
+++ b/rules/nod-structures.yaml
@@ -369,7 +369,7 @@ NARADR:
 		Queue: Building.Nod
 		BuildPaletteOrder: 206
 		Prerequisites: anypower, nproc, ~structures.nod, ~ideology
-		Description: Provides an overview of the battlefield.\n\nSpecial:\n- Provides minimap\n- Provides special infantry taskforce drop (Technology)\n- Provides a special buff ability to increase attack and movement speed of infantry (Propaganda)\n- Detects underground units\n- Provides a Radar Scan ability
+		Description: Provides an overview of the battlefield.\n\nSpecial:\n- Provides minimap\n- Allows calling Subterranean APCs\n- Provides special infantry taskforce drop (Technology)\n- Provides a special buff ability to increase attack and movement speed of infantry (Propaganda)\n- Detects underground units\n- Provides a Radar Scan ability
 	Valued:
 		Cost: 1500
 	Tooltip:

--- a/rules/nod-structures.yaml
+++ b/rules/nod-structures.yaml
@@ -340,22 +340,6 @@ NAWEAP:
 	Power:
 		Amount: -50
 	ProvidesPrerequisite@buildingname:
-	SpawnActorPower@subambush:
-		OrderName: SubAmbushPowerInfoOrder
-		Prerequisites: nahand, ~industry
-		Description: Subterranean APC Ambush
-		LongDesc: Spawns a fully loaded Subterranean APC.
-		Actor: sapc1
-		Icon: subapcambush
-		LifeTime: -1
-		DeploySound: drillup.aud
-		EffectImage: dig
-		EffectPalette: player
-		EffectSequence: idle
-		ChargeTime: 240
-		SelectTargetSpeechNotification: SelectTarget
-		LowPowerSpeechNotification: LowPower
-		LaunchSpeechNotification: Reinforce
 	GrantExternalConditionPower@emergencyrepairNod:
 		OrderName: EmergancyRepairs2PowerInfoOrder
 		Prerequisites: ~industry
@@ -452,6 +436,22 @@ NARADR:
 		CircleSequence: circles
 		ClockSequence: clock
 		Sequence: idle
+	SpawnActorPower@subambush:
+		OrderName: SubAmbushPowerInfoOrder
+		Prerequisites: ~industry
+		Description: Subterranean APC Ambush
+		LongDesc: Spawns a fully loaded Subterranean APC.
+		Actor: sapc1
+		Icon: subapcambush
+		LifeTime: -1
+		DeploySound: drillup.aud
+		EffectImage: dig
+		EffectPalette: player
+		EffectSequence: idle
+		ChargeTime: 240
+		SelectTargetSpeechNotification: SelectTarget
+		LowPowerSpeechNotification: LowPower
+		LaunchSpeechNotification: Reinforce
 
 NAHPAD:
 	Inherits: ^Building

--- a/rules/nod-support.yaml
+++ b/rules/nod-support.yaml
@@ -143,17 +143,14 @@ NAFLAMER:
 		Amount: -50
 	WithSpriteTurret:
 		Recoils: False
-#	GrantConditionOnPrerequisite@upgrade1:
-#		Condition: upgrade.stealth
-#		Prerequisites: upgrade.stealth
 	GrantConditionOnPrerequisite@upgrade2:
 		Condition: upgrade.bluehell
 		Prerequisites: upgrade.bluehell
 	GrantConditionOnPrerequisite@upgrade3:
 		Condition: upgrade.tibgas
 		Prerequisites: upgrade.tibgas
-#	Cloak:
-#		RequiresCondition: upgrade.stealth || cloak
+	Cloak:
+		RequiresCondition: cloak
 	RenderDetectionCircle:
 	DetectCloaked:
 		Range: 8c497
@@ -342,17 +339,11 @@ NASAM:
 		RequiresCondition: upgrade.tibgas
 	Power:
 		Amount: -50
-#	GrantConditionOnPrerequisite@upgrade1:
-#		Condition: upgrade.stealth
-#		Prerequisites: upgrade.stealth
-#	GrantConditionOnPrerequisite@upgrade2:
-#		Condition: industry
-#		Prerequisites: industry
 	GrantConditionOnPrerequisite@upgrade3:
 		Condition: upgrade.tibgas
 		Prerequisites: upgrade.tibgas
-#	Cloak:
-#		RequiresCondition: upgrade.stealth || cloak
+	Cloak:
+		RequiresCondition: cloak
 	WithMuzzleOverlay:
 	ProvidesPrerequisite@buildingname:
 

--- a/rules/nod-support.yaml
+++ b/rules/nod-support.yaml
@@ -97,9 +97,9 @@ NAFLAMER:
 		Name: Flame Turret
 	Buildable:
 		Queue: Defense.Nod
-		Prerequisites: anypower, nahand, ~structures.nod, ~ideology, ~!industry
+		Prerequisites: anypower, nahand, ~structures.nod, ~ideology, ~!technology
 		BuildPaletteOrder: 203
-		Description: Anti-Infantry base defense.\n\nGood vs: Infantry, Buildings\n\nSpecial:\n- Provides stealth detection\n- Stealth Emitter (Technology)\n- Blue Hell Inferno (Propaganda)\n- Requires power to operate
+		Description: Anti-Infantry base defense.\n\nGood vs: Infantry, Buildings\n\nSpecial:\n- Provides stealth detection\n- Tiberium Weapons Research (Industry)\n- Blue Hell Inferno (Propaganda)\n- Requires power to operate
 	Building:
 	Selectable:
 		Bounds: 40, 36, -3, -8
@@ -118,11 +118,11 @@ NAFLAMER:
 	Armament@right:
 		Weapon: FlamerTurretFireballLauncher
 		LocalOffset: 990,255,919
-		RequiresCondition: !upgrade.bluehell
+		RequiresCondition: !upgrade.bluehell && !upgrade.tibgas
 	Armament@left:
 		Weapon: FlamerTurretFireballLauncher
 		LocalOffset: 990,-255,919
-		RequiresCondition: !upgrade.bluehell
+		RequiresCondition: !upgrade.bluehell && !upgrade.tibgas
 	Armament@upgrade1:
 		Weapon: FlamerTurretBlueFireballLauncher
 		LocalOffset: 990,255,919
@@ -131,18 +131,29 @@ NAFLAMER:
 		Weapon: FlamerTurretBlueFireballLauncher
 		LocalOffset: 990,-255,919
 		RequiresCondition: upgrade.bluehell
-	Power:
+	Armament@upgrade3:
+		Weapon: FlamerTurretTiberium
+		LocalOffset: 990,255,919
+		RequiresCondition: !upgrade.bluehell && upgrade.tibgas
+	Armament@upgrade4:
+		Weapon: FlamerTurretTiberium
+		LocalOffset: 990,-255,919
+		RequiresCondition: !upgrade.bluehell && upgrade.tibgas
+    Power:
 		Amount: -50
 	WithSpriteTurret:
 		Recoils: False
-	GrantConditionOnPrerequisite@upgrade1:
-		Condition: upgrade.stealth
-		Prerequisites: upgrade.stealth
+#	GrantConditionOnPrerequisite@upgrade1:
+#		Condition: upgrade.stealth
+#		Prerequisites: upgrade.stealth
 	GrantConditionOnPrerequisite@upgrade2:
 		Condition: upgrade.bluehell
 		Prerequisites: upgrade.bluehell
-	Cloak:
-		RequiresCondition: upgrade.stealth || cloak
+    GrantConditionOnPrerequisite@upgrade3:
+		Condition: upgrade.tibgas
+		Prerequisites: upgrade.tibgas
+#	Cloak:
+#		RequiresCondition: upgrade.stealth || cloak
 	RenderDetectionCircle:
 	DetectCloaked:
 		Range: 8c497
@@ -162,9 +173,9 @@ NAGAT:
 		Name: Gattling Cannon
 	Buildable:
 		Queue: Defense.Nod
-		Prerequisites: anypower, nahand, ~structures.nod, ~industry
+		Prerequisites: anypower, nahand, ~structures.nod, ~technology
 		BuildPaletteOrder: 203
-		Description: Anti-Infantry and Anti-Air base defense for Industry Nod.\n\nGood vs: Infantry, Air\n\nSpecial:\n- Can shoot against ground and air\n- Provides stealth detection\n- Requires power to operate
+		Description: Anti-Infantry and Anti-Air base defense for Technology Nod.\n\nGood vs: Infantry, Air\n\nSpecial:\n- Can shoot against ground and air\n- Provides stealth detection\n- Requires power to operate\n- Stealth Emitters (Technology)
 	Building:
 	Selectable:
 		Bounds: 40, 36, -3, -8
@@ -205,7 +216,12 @@ NAGAT:
 		RecoilRecovery: 5
 	Power:
 		Amount: -50
+    GrantConditionOnPrerequisite@upgrade1:
+		Condition: upgrade.stealth
+		Prerequisites: upgrade.stealth
 	WithMuzzleOverlay:
+    Cloak:
+		RequiresCondition: upgrade.stealth || cloak
 	RenderDetectionCircle:
 	DetectCloaked:
 		Range: 8c497
@@ -288,9 +304,9 @@ NASAM:
 		Name: SAM Site
 	Buildable:
 		Queue: Defense.Nod
-		Prerequisites: anypower, naradr, ~structures.nod, ~ideology, ~!industry
+		Prerequisites: anypower, naradr, ~structures.nod, ~ideology, ~!technology
 		BuildPaletteOrder: 205
-		Description: Anti-Air base defense for Technology and Propaganda Nod.\n\nGood vs: Air\n\nSpecial:\n- Can only shoot against air\n- Stealth Emitter (Technology)\n- Requires power to operate
+		Description: Anti-Air base defense for Industry and Propaganda Nod.\n\nGood vs: Air\n\nSpecial:\n- Can only shoot against air\n- Tiberium Weapons Research (Industry)\n- Requires power to operate
 	Building:
 	Selectable:
 		Bounds: 40, 36, -3, -8
@@ -315,17 +331,28 @@ NASAM:
 		MuzzlePalette: apolra50alpha
 		Recoil: 25
 		RecoilRecovery: 10
-		RequiresCondition: !industry
+		RequiresCondition: !upgrade.tibgas
+	Armament@tib:
+		Weapon: SAMSiteMissileTiberium
+		LocalOffset: 566,0,1273
+		MuzzleSequence: muzzle
+		MuzzlePalette: apolra50alpha
+		Recoil: 25
+		RecoilRecovery: 10
+		RequiresCondition: upgrade.tibgas
 	Power:
 		Amount: -50
-	GrantConditionOnPrerequisite@upgrade1:
-		Condition: upgrade.stealth
-		Prerequisites: upgrade.stealth
-	GrantConditionOnPrerequisite@upgrade2:
-		Condition: industry
-		Prerequisites: industry
-	Cloak:
-		RequiresCondition: upgrade.stealth || cloak
+#	GrantConditionOnPrerequisite@upgrade1:
+#		Condition: upgrade.stealth
+#		Prerequisites: upgrade.stealth
+#	GrantConditionOnPrerequisite@upgrade2:
+#		Condition: industry
+#		Prerequisites: industry
+    GrantConditionOnPrerequisite@upgrade3:
+		Condition: upgrade.tibgas
+		Prerequisites: upgrade.tibgas
+#	Cloak:
+#		RequiresCondition: upgrade.stealth || cloak
 	WithMuzzleOverlay:
 	ProvidesPrerequisite@buildingname:
 
@@ -380,7 +407,7 @@ NAOBEL:
 		Queue: Defense.Nod
 		BuildPaletteOrder: 206
 		Prerequisites: anypower, napyra, ~structures.nod, ~ideology
-		Description: High Tech base defense.\n\nGood vs: Ground\n\nSpecial:\n- Provides stealth detection\n- Tiberium Weapons Research (Industry)\n- Improved Laser Emitter (Technology)\n- Requires power to operate
+		Description: High Tech base defense.\n\nGood vs: Ground\n\nSpecial:\n- Provides stealth detection\n- Tiberium Weapons Research (Industry)\n- Improved Laser Emitter (Technology)\n- Stealth Emitters (Technology)\n- Requires power to operate
 	Building:
 		Footprint: xx xx
 		Dimensions: 2,2
@@ -428,7 +455,12 @@ NAOBEL:
 		PauseOnCondition: power-outage
 	Power:
 		Amount: -150
-	WithMuzzleOverlay:
+    GrantConditionOnPrerequisite@upgrade1:
+		Condition: upgrade.stealth
+		Prerequisites: upgrade.stealth
+	Cloak:
+		RequiresCondition: upgrade.stealth || cloak
+    WithMuzzleOverlay:
 	GrantConditionOnPrerequisite@tiblaser:
 		Condition: upgrade.tiblaser
 		Prerequisites: upgrade.tiblaser

--- a/rules/nod-support.yaml
+++ b/rules/nod-support.yaml
@@ -139,7 +139,7 @@ NAFLAMER:
 		Weapon: FlamerTurretTiberium
 		LocalOffset: 990,-255,919
 		RequiresCondition: !upgrade.bluehell && upgrade.tibgas
-    Power:
+	Power:
 		Amount: -50
 	WithSpriteTurret:
 		Recoils: False
@@ -149,7 +149,7 @@ NAFLAMER:
 	GrantConditionOnPrerequisite@upgrade2:
 		Condition: upgrade.bluehell
 		Prerequisites: upgrade.bluehell
-    GrantConditionOnPrerequisite@upgrade3:
+	GrantConditionOnPrerequisite@upgrade3:
 		Condition: upgrade.tibgas
 		Prerequisites: upgrade.tibgas
 #	Cloak:
@@ -216,11 +216,11 @@ NAGAT:
 		RecoilRecovery: 5
 	Power:
 		Amount: -50
-    GrantConditionOnPrerequisite@upgrade1:
+	GrantConditionOnPrerequisite@upgrade1:
 		Condition: upgrade.stealth
 		Prerequisites: upgrade.stealth
 	WithMuzzleOverlay:
-    Cloak:
+	Cloak:
 		RequiresCondition: upgrade.stealth || cloak
 	RenderDetectionCircle:
 	DetectCloaked:
@@ -348,7 +348,7 @@ NASAM:
 #	GrantConditionOnPrerequisite@upgrade2:
 #		Condition: industry
 #		Prerequisites: industry
-    GrantConditionOnPrerequisite@upgrade3:
+	GrantConditionOnPrerequisite@upgrade3:
 		Condition: upgrade.tibgas
 		Prerequisites: upgrade.tibgas
 #	Cloak:
@@ -455,12 +455,12 @@ NAOBEL:
 		PauseOnCondition: power-outage
 	Power:
 		Amount: -150
-    GrantConditionOnPrerequisite@upgrade1:
+	GrantConditionOnPrerequisite@upgrade1:
 		Condition: upgrade.stealth
 		Prerequisites: upgrade.stealth
 	Cloak:
 		RequiresCondition: upgrade.stealth || cloak
-    WithMuzzleOverlay:
+	WithMuzzleOverlay:
 	GrantConditionOnPrerequisite@tiblaser:
 		Condition: upgrade.tiblaser
 		Prerequisites: upgrade.tiblaser

--- a/rules/nod-tech.yaml
+++ b/rules/nod-tech.yaml
@@ -44,7 +44,7 @@ upgrade.industry.tiblaser:
 		Prerequisites: ~industry, napyra, ~!upgrade.tiblaser
 		Queue: Tech.Nod
 		BuildLimit: 1
-		Description: Improves the weapon of following units and buildings and causes them to create visceroids:\n- Hydra (Tiberium Laser + Tiberium AG Rockets)\n- Raven (Tiberium Rockets)\n- Gorran (Tiberium AG Rockets)\n- Hailstorm (Tibeirum Rockets)\n- Laser Turret (Tiberium Laser)\n- Obelisk of Light (Tiberium Laser)
+		Description: Improves the weapon of following units and buildings in damage and causes them to create visceroids:\n- Hydra\n- Raven\n- Gorran (Adding a Tiberium AG Rocket)\n- Devils Tongue (weapon also spreads gas)\n- Hailstorm (weapon also spreads gas)\n- Laser Turret\n- Obelisk of Light\n- Flame Turret\n- Sam Site
 	Valued:
 		Cost: 2000
 	RenderSprites:
@@ -100,7 +100,7 @@ upgrade.tech.stealth:
 		Prerequisites: ~technology, napyra, ~!upgrade.stealth
 		Queue: Tech.Nod
 		BuildLimit: 1
-		Description: Grants invisibilty to following units and structures:\n- Elite Cadre\n- Rocketeer\n- Engineer\n- Shadow Trooper\n- Specter Artillery\n- Flame Turret\n- Laser Turret\n- SAM Site
+		Description: Grants invisibilty to following units and structures:\n- Elite Cadre\n- Rocketeer\n- Engineer\n- Shadow Trooper\n- MRD\n- Specter Artillery\n- Gattling Cannon\n- Laser Turret\n- Obelisk of Light
 	Valued:
 		Cost: 1500
 	RenderSprites:

--- a/rules/nod-vehicles.yaml
+++ b/rules/nod-vehicles.yaml
@@ -479,7 +479,7 @@ BIKE:
 	Health:
 		HP: 350
 	RevealsShroud:
-		Range: 9c921
+		Range: 10c921
 	Armament@PRIMARY:
 		Weapon: BikeMissile
 		LocalOffset: 0,-232,622, 0,233,622
@@ -565,7 +565,7 @@ REPAIR:
 		Queue: Vehicle.Nod
 		BuildPaletteOrder: 204
 		Prerequisites: ~naweap, naradr
-		Description: The repair vehicle in the arsenal of Nod.\n\nGood vs: Nothing\n\nSpecial:\n- Repairs vehicles directly\n- Has a weak repair buff on vehicles in an area around him\n- Crush class: Light vehicle
+		Description: The repair vehicle in the arsenal of Nod.\n\nGood vs: Nothing\n\nSpecial:\n- Repairs vehicles directly\n- Has a weak repair buff on vehicles in an area around him\n- Stealth Emitters (Technology)\n- Crush class: Light vehicle
 	Voiced:
 		VoiceSet: Cabalbeep
 		Volume: 2
@@ -600,7 +600,14 @@ REPAIR:
 	WithRangeCircle:
 		Color: FFFFFFFF
 		Range: 7c73
-	WithVoxelBody:
+	Cloak:
+		RequiresCondition: upgrade.stealth || cloak
+		InitialDelay: 90
+		CloakDelay: 250
+    GrantConditionOnPrerequisite@upgrade1:
+		Condition: upgrade.stealth
+		Prerequisites: upgrade.stealth
+    WithVoxelBody:
 	WithVoxelTurret:
 		Recoils: False
 	HitShape:
@@ -1186,7 +1193,7 @@ AVATAR:
 		Volume: 2
 	Mobile:
 		TurnSpeed: 5
-		Speed: 65
+		Speed: 70
 	GrantConditionOnMovement@steps:
 		Condition: walker
 	AmbientSound@step1:

--- a/rules/nod-vehicles.yaml
+++ b/rules/nod-vehicles.yaml
@@ -604,10 +604,10 @@ REPAIR:
 		RequiresCondition: upgrade.stealth || cloak
 		InitialDelay: 90
 		CloakDelay: 250
-    GrantConditionOnPrerequisite@upgrade1:
+	GrantConditionOnPrerequisite@upgrade1:
 		Condition: upgrade.stealth
 		Prerequisites: upgrade.stealth
-    WithVoxelBody:
+	WithVoxelBody:
 	WithVoxelTurret:
 		Recoils: False
 	HitShape:

--- a/weapons/cabal-weapons.yaml
+++ b/weapons/cabal-weapons.yaml
@@ -913,7 +913,7 @@ ShockwaveTesla:
 	ReloadDelay: 60
 	Range: 6c11
 	Report: lastur2.aud, lastur3.aud, lastur4.aud
-	Burst: 3
+	Burst: 2
 	BurstDelay: 4
 	Projectile: TeslaZap
 		Palette: apolcyan
@@ -1069,7 +1069,7 @@ ReaperMissile:
 	Inherits: ^MissileAPHE
 	Inherits@wh: ^APWH
 	ReloadDelay: 100
-	Range: 8c497
+	Range: 9c559
 	Burst: 2
 	BurstDelay: 10
 	Report: rocket01.aud, rocket02.aud, rocket03.aud, rocket04.aud, rocket05.aud, rocket06.aud
@@ -1155,7 +1155,7 @@ cleansingaura:
 		ValidStances: None, Enemy, Neutral, Ally
 
 Hightensionbomb:
-	ReloadDelay: 10
+	ReloadDelay: 10000
 	Range: 1c100
 	Burst: 1
 	BurstDelay: 1

--- a/weapons/gdi-weapons.yaml
+++ b/weapons/gdi-weapons.yaml
@@ -60,7 +60,7 @@ ZoneCommandoGun:
 	Warhead@1Dam: SpreadDamage
 		Spread: 0c181
 		Damage: 150
-        Versus:
+		Versus:
 			Infantry: 100
 			Cyborg: 100
 			Vehicle: 100
@@ -583,7 +583,7 @@ CondorBomb:
 	Warhead@1Dam: SpreadDamage
 		Spread: 0c362
 		Damage: 800
-        Versus:
+		Versus:
 			Infantry: 100
 			Cyborg: 100
 			Vehicle: 100

--- a/weapons/gdi-weapons.yaml
+++ b/weapons/gdi-weapons.yaml
@@ -60,6 +60,12 @@ ZoneCommandoGun:
 	Warhead@1Dam: SpreadDamage
 		Spread: 0c181
 		Damage: 150
+        Versus:
+			Infantry: 100
+			Cyborg: 100
+			Vehicle: 100
+			Aircraft: 100
+			Building: 100
 	Warhead@2Eff: CreateEffect
 		Explosions: plasmawave1
 		ExplosionPalette: effect50alpha
@@ -376,7 +382,7 @@ IonCannon:
 ZoneMarineGun:
 	Inherits: ^Bullet
 	Inherits@wh: ^BulletWH
-	ReloadDelay: 60
+	ReloadDelay: 50
 	Range: 7c73
 	Burst: 3
 	BurstDelay: 4
@@ -576,7 +582,13 @@ CondorBomb:
 		ContrailWidth: 0c35
 	Warhead@1Dam: SpreadDamage
 		Spread: 0c362
-		Damage: 700
+		Damage: 800
+        Versus:
+			Infantry: 100
+			Cyborg: 100
+			Vehicle: 100
+			Aircraft: 100
+			Building: 100
 	Warhead@2Eff: CreateEffect
 		Explosions: swave
 		ExplosionPalette: swave
@@ -1130,7 +1142,7 @@ OrcaF1Missiles:
 
 OrcaF2Missiles:
 	Inherits: OrcaF1Missiles
-	ReloadDelay: 160
+	ReloadDelay: 120
 	ValidTargets: Ground
 	Range: 8c497
 	MinRange: 1c424
@@ -1316,7 +1328,7 @@ HoverMRLSMissile:
 HoverMRLSMissileAA:
 	Inherits: ^MissileAPHE
 	Inherits@wh: ^APHEWH
-	ReloadDelay: 200
+	ReloadDelay: 150
 	Burst: 8
 	BurstDelay: 2
 	Range: 11c321
@@ -1327,10 +1339,10 @@ HoverMRLSMissileAA:
 		MinimumLaunchSpeed: 0c91
 		Speed: 0c724
 		RangeLimit: 28c291
-		Inaccuracy: 0c724
+		Inaccuracy: 0c362
 		TerrainHeightAware: true
 	Warhead@1Dam: SpreadDamage
-		Spread: 0c1
+		Spread: 0c362
 		Damage: 60
 		ValidTargets: Aircraft
 

--- a/weapons/nod-weapons.yaml
+++ b/weapons/nod-weapons.yaml
@@ -1797,8 +1797,8 @@ FlamerTurretFireballLauncher:
 FlamerTurretTiberium:
 	Inherits@wh: BlueFireballLauncher
 	ReloadDelay: 100
-    Burst: 2
-    BurstDelay: 20
+	Burst: 2
+	BurstDelay: 20
 	Range: 7c435
 	Report: flamtnk1.aud
 	Projectile: BulletAS
@@ -1813,7 +1813,7 @@ FlamerTurretTiberium:
 		Spread: 1c424
 		Damage: 55
 		Falloff: 100, 80
-    Warhead@2Eff: CreateEffect
+	Warhead@2Eff: CreateEffect
 		Explosions: fire01a, fire02a, fire03a
 		ExplosionPalette: beamzap
 	Warhead@3Smu: LeaveSmudge
@@ -2060,7 +2060,7 @@ HailstormMissileGas:
 		ExplosionPalette: effect50alpha
 		ImpactSounds: expnew12.aud
 		InvalidTargets: Water, Aircraft
-    WarheadAS: SpawnActor
+	WarheadAS: SpawnActor
 		Range: 1
 		Actors: Cloud1
 		Owner: Creeps
@@ -2246,7 +2246,7 @@ SAMSiteMissileTiberium:
 		ContrailLength: 10
 		ContrailColor: 00FF64
 		ContrailWidth: 0c21
-        TerrainHeightAware: true
+		TerrainHeightAware: true
 	Warhead@1Dam: SpreadDamage
 		Spread: 0c724
 		Damage: 175

--- a/weapons/nod-weapons.yaml
+++ b/weapons/nod-weapons.yaml
@@ -39,7 +39,7 @@ DevilsTongueGunTiberium:
 		Falloff: 100, 80
 	WarheadAS: SpawnActor
 		Range: 1
-		Actors: Cloud1, Cloud2
+		Actors: Cloud1
 		Owner: Creeps
 
 PyradonGun:
@@ -1744,7 +1744,7 @@ FlamerTurretBlueFireballLauncher:
 		Inaccuracy: 1c424
 	Warhead@1Dam: SpreadDamage
 		Spread: 1c424
-		Damage: 50
+		Damage: 65
 		Falloff: 100, 90, 80
 	Warhead@2Eff: CreateEffect
 		Explosions: fire01a, fire02a, fire03a
@@ -1777,7 +1777,7 @@ FlamerTurretFireballLauncher:
 		Inaccuracy: 1c424
 	Warhead@1Dam: SpreadDamage
 		Spread: 1c424
-		Damage: 40
+		Damage: 45
 		Falloff: 100, 80
 	Warhead@2Eff: CreateEffect
 		Explosions: fire01a, fire02a, fire03a
@@ -1793,6 +1793,40 @@ FlamerTurretFireballLauncher:
 		Weapon: TermiteGunShrapnel
 		Amount: 4
 		AimChance: 0
+
+FlamerTurretTiberium:
+	Inherits@wh: BlueFireballLauncher
+	ReloadDelay: 100
+    Burst: 2
+    BurstDelay: 20
+	Range: 7c435
+	Report: flamtnk1.aud
+	Projectile: BulletAS
+		Speed: 0c181
+		LaunchAngle: 90
+		Image: tibflametrailer
+		TrailImage: tibflametrailer
+		TrailPalette: effect50alpha
+		Inaccuracy: 1c424
+		DamageTypes: TriggerVisceroid
+	Warhead@1Dam: SpreadDamage
+		Spread: 1c424
+		Damage: 55
+		Falloff: 100, 80
+    Warhead@2Eff: CreateEffect
+		Explosions: fire01a, fire02a, fire03a
+		ExplosionPalette: beamzap
+	Warhead@3Smu: LeaveSmudge
+		SmudgeType: MediumScorch
+	Warhead@4Smu: LeaveSmudge
+		SmudgeType: SmallScorch
+	Warhead@6Eff: CreateEffect
+		Explosions: medium_flash
+		ExplosionPalette: light2
+	WarheadAS: SpawnActor
+		Range: 1
+		Actors: Cloud1
+		Owner: Creeps
 
 FanticBoom:
 	Inherits@wh: ^HEAPWH
@@ -1866,7 +1900,7 @@ BikeMissile:
 	ReloadDelay: 100
 	Burst: 2
 	BurstDelay: 20
-	Range: 8c497
+	Range: 9c559
 	Report: misl1.aud
 	ValidTargets: Ground
 	Projectile: Missile
@@ -1991,10 +2025,6 @@ HailstormMissile:
 		Versus:
 			Building: 175
 		ValidTargets: Ground
-	WarheadAS: SpawnActor
-		Range: 1
-		Actors: Cloud1, Cloud2
-		Owner: Creeps
 
 HailstormMissileAA:
 	Inherits: HailstormMissile
@@ -2030,6 +2060,10 @@ HailstormMissileGas:
 		ExplosionPalette: effect50alpha
 		ImpactSounds: expnew12.aud
 		InvalidTargets: Water, Aircraft
+    WarheadAS: SpawnActor
+		Range: 1
+		Actors: Cloud1
+		Owner: Creeps
 
 HailstormMissileGasAA:
 	Inherits: HailstormMissileGas
@@ -2182,6 +2216,40 @@ SAMSiteMissile:
 	Warhead@1Dam: SpreadDamage
 		Spread: 0c724
 		Damage: 150
+		ValidTargets: Aircraft
+	Warhead@2Eff: CreateEffect
+		Explosions: tiny_tumu
+		ExplosionPalette: apolra50alpha
+		ImpactSounds: expnew12.aud, explosion01.aud, explosion02.aud
+
+SAMSiteMissileTiberium:
+	Inherits: ^MissileAPHE
+	Inherits@wh: ^APHEWH
+	Range: 11c321
+	ReloadDelay: 75
+	Burst: 3
+	BurstDelay: 10
+	Report: rocket01.aud, rocket02.aud, rocket03.aud, rocket04.aud, rocket05.aud, rocket06.aud
+	ValidTargets: Aircraft
+	Projectile: Missile
+		MaximumLaunchSpeed: 1c512
+		MinimumLaunchSpeed: 1c512
+		Speed: 1c512
+		Arm: 2
+		Blockable: false
+		Shadow: true
+		Inaccuracy: 0c0
+		Image: missile01
+		HorizontalRateOfTurn: 8
+		RangeLimit: 42c437
+		CloseEnough: 2c0
+		ContrailLength: 10
+		ContrailColor: 00FF64
+		ContrailWidth: 0c21
+        TerrainHeightAware: true
+	Warhead@1Dam: SpreadDamage
+		Spread: 0c724
+		Damage: 175
 		ValidTargets: Aircraft
 	Warhead@2Eff: CreateEffect
 		Explosions: tiny_tumu


### PR DESCRIPTION
    GDI:
    Zone Command Drop:
    removed the commando from it
    changed the drop to 3 Zone Troopers and 3 Zone Raiders
    Titan Mech Drop:
    removed the Titan MKII from it
    Drops 4 Titans in total
    Poseidon Tank Drop:
    removed Poseidon tank from it
    drops 3 Grizzly Tanks in total
    renamed to Grizzly Tank Drop
    remove the ability from Steel Talons and added it to GDF
    its now available via lockingin GDF as a subfacion while having a Techlab
    APC Tooltip updated: can detect stealth
    Vulture Tooltip updated: can detect stealth
    Zone Commander:
    buildable for ZOCOM:
    cost to 4000$
    available upon techlab
    buildlimit of 1
    heavy crush class
    renamed to Colonel Mobius
    added selfhealing
    damage stats:
            Damage: 150
            Versus:
                Infantry: 100
                Cyborg: 100
                Vehicle: 100
                Aircraft: 100
                Building: 100
    Artillery Strike
    Artillery_Beacon speed from 424 to 150
    Titan:
    new weapon called TitanAP
    same stats as the 122mmAP weapon but instead of 9c559 to 11c0 attackrange
    HP from 1440 to 1200
    Zone Marine:
    ZoneMarineGun reloadspeed from 60 to 50
    cost from 200$ to 175$
    Orca-F2:
    cost from 1200$ to 1350$
    reloadspeed from 160 to 120
    Hellfire Missiles:
    moved Steel Talon Dropship bay (the ability was originally for Steel Talons)
    renamed it from A huge Rocketbombardment to Hellfire Missiles
    speed of the Kodiak from 68 to 150
    Condor:
    Movementspeed from 200 to 220
    damage of CondorBomb from 700 to 800
    damage stats:
            Versus:
                Infantry: 100
                Cyborg: 100
                Vehicle: 100
                Aircraft: 100
                Building: 100
    Hover MLRS:
    HoverMRLSMissileAA:
    inacccuracy from 0c724 to 0c362
    spread from 0c1 to 0c362
    reloadspeed from 200 to 150

    Nod:
    Paraunitdrop Carryall not targetable anymore
    Rookies from 60$ to 70$ (the propaganda nod upgraded rookies from 30$ to 35$)
    Flame Turret:
    vanilla: damage from 40 to 45
    bluehellinferno: damage from 50 to 65
    tiberium warheads: damage to 55
    Industry Nod:
    Swapped Gattlingturret with Flameturret, adding Samside aswell
    Flameturret will be effected by Tiberiums Warheads Upgrade (kinda like the devils tongue)
    Sam Site also improves its damage via Tiberium Warheads
    upgrade increases the damage from 150 to 175
    Havocs are targetable again
    Hydra from 1400$ to 1650$
    changed cloudspawning rate of Devil Tognue, Hailstorm and Flame Turret from 2 clouds per projectile to 1 cloud per projectile
    Avatar movementspeed from 65 to 70
    Attackbike attackrange from 8c497 to 9c559
    revealsshorud from 9c921 to 10c921

    Cabal:
    Shockwave:
    burst from 3 to 2 (now shoots 4 times instead of 6)
    Reaper:
    attackrange from 8c497 to 9c559
    Total Meltdown fixed
    reloadspeed from 10 to 10000 (now doesn´t shoot 2 bombs anymore)
    Renaming Upgrades:
    Teleporter to "Experimental Phase Jump"
    Vision Uplink to "Optics Augmentation"
    Alloyed Chassis to "Organic Polymers" or "Cybernetic Legs"
    Advanced Platings to "Fullerene Construction Techniques"