### PR TITLE
Cabal balance changes.

### DIFF
--- a/rules/cabal-infantry.yaml
+++ b/rules/cabal-infantry.yaml
@@ -194,7 +194,7 @@ KENGINEER:
 		VoiceSet: Ascentor
 		Volume: 2
 	Mobile:
-		Speed: 34
+		Speed: 30
 	RevealsShroud:
 		RequiresCondition: !upgrade.visionuplink
 		Range: 8c497
@@ -202,7 +202,7 @@ KENGINEER:
 		RequiresCondition: upgrade.visionuplink
 		Range: 10c497
 	Health:
-		HP: 400
+		HP: 700
 	Passenger:
 		PipType: Yellow
 	EngineerRepair:

--- a/rules/cabal-tech.yaml
+++ b/rules/cabal-tech.yaml
@@ -72,7 +72,7 @@ upgrade.teleporter:
 		Queue: Tech.Cabal
 		Description: Research the Teleporter which allows teleporting a small group of units.
 	Valued:
-		Cost: 2000
+		Cost: 1500
 	RenderSprites:
 		Image: KACNST
 	Plug:
@@ -88,7 +88,7 @@ upgrade.nanoswarm:
 		Queue: Tech.Cabal
 		Description: Research the Nanoswarm which allows making a small group of units invulnerable.
 	Valued:
-		Cost: 2500
+		Cost: 2000
 	RenderSprites:
 		Image: KAGATE_A
 	Plug:
@@ -120,7 +120,7 @@ upgrade.mantastrike:
 		Queue: Tech.Cabal
 		Description: Research a fighter aircraft which attacks everything in an area of the map.
 	Valued:
-		Cost: 3000
+		Cost: 1500
 	RenderSprites:
 		Image: MANTA
 	Plug:
@@ -136,7 +136,7 @@ upgrade.overload:
 		Queue: Tech.Cabal
 		Description: Research a method to temporarily boost powerplants.
 	Valued:
-		Cost: 3000
+		Cost: 1000
 	RenderSprites:
 		Image: KALASR
 	Plug:

--- a/rules/cabal-vehicles.yaml
+++ b/rules/cabal-vehicles.yaml
@@ -197,7 +197,7 @@ REAPER:
 	Inherits@FeatureAutotargetVehicle: ^FeatureAutotargetVehicle3
 	Inherits@FeatureAutotargetBuilding: ^FeatureAutotargetBuilding4
 	Valued:
-		Cost: 1300
+		Cost: 1200
 	Tooltip:
 		Name: Reaper
 	Selectable:
@@ -414,8 +414,8 @@ SILVER:
 		HP: 500
 	Cargo:
 		Types: Infantry
-		MaxWeight: 7
-		PipCount: 7
+		MaxWeight: 10
+		PipCount: 10
 		EjectOnDeath: False
 	RenderSprites:
 	RenderVoxels:
@@ -429,7 +429,7 @@ SILVER:
 	-ThrowsShrapnel@human:
 	Mobile:
 		TurnSpeed: 5
-		Speed: 80
+		Speed: 90
 	HitShape:
 
 KRONOS:

--- a/weapons/cabal-weapons.yaml
+++ b/weapons/cabal-weapons.yaml
@@ -324,7 +324,7 @@ CannonHuskGun:
 		ContrailWidth: 0c71
 	Warhead@1Dam: SpreadDamage
 		Spread: 0c362
-		Damage: 40
+		Damage: 50
 		DamageTypes: CabalWeapon, TakeCoverEffect, SmallExplosionDeath
 	Warhead@2Eff: CreateEffect
 		Explosions: plasmaexpl1
@@ -746,7 +746,7 @@ SabercutTesla:
 			Cyborg: 100
 			Vehicle: 15
 			Aircraft: 15
-			Building: 75
+			Building: 30
 		DamageTypes: CabalWeapon
 	Warhead@3Eff: CreateEffect
 		Explosions: small_emp
@@ -1039,7 +1039,7 @@ JaguarClaw:
 
 WebLauncher:
 	ValidTargets: Infantry
-	ReloadDelay: 120
+	ReloadDelay: 200
 	Range: 14c146
 	Burst: 3
 	BurstDelay: 5
@@ -1061,7 +1061,7 @@ WebLauncher:
 		ImpactSounds: fireweb1.aud
 	Warhead@emp: GrantExternalCondition
 		Range: 0c724
-		Duration: 90
+		Duration: 160
 		Condition: webdisable
 		ValidTargets: Infantry
 
@@ -1086,6 +1086,8 @@ ReaperMissile:
 	Warhead@1Dam: SpreadDamage
 		Spread: 0c181
 		Damage: 100
+		Versus:
+			Building: 50
 		ValidTargets: Ground
 		DamageTypes: CabalWeapon
 	Warhead@2Eff: CreateEffect
@@ -1120,6 +1122,8 @@ ReaperClusterMissile:
 	Warhead@1Dam: SpreadDamage
 		Spread: 0c181
 		Damage: 30
+		Versus:
+			Building: 50
 		ValidTargets: Ground
 		DamageTypes: CabalWeapon, Prone350Percent, TriggerProne, EnergyDeath
 


### PR DESCRIPTION
  Reaper:

    ReaperMissile damage against buildings from 100% to 50%

    from 1300$ to 1200$

    Sabercut

    Less damage to buildings from 75% down to 30%

    Helion:

    Movementspeed from 80 to 90

    increase the capacity from 7 to 10

    Cannon Husk:

    damage increase from 40 to 50

    Ascentor /Engineer):

    HP from 400 to 700

    movementspeed from 34 to 30

    WebLauncher:

    reloaddelay from 120 to 200

    web stun duration of infantry from 90 to 160

    Ability Overload:

    from 3000$ to 1000$

    Mantastrike:

    to 1500$

    Nanoswarm:

    from 2500$ to 2000$

    Teleport:

    2000$ to 1500$